### PR TITLE
Add React+Supabase sample

### DIFF
--- a/contributing/samples/react_supabase/README.md
+++ b/contributing/samples/react_supabase/README.md
@@ -1,0 +1,29 @@
+# React + Supabase Integration Sample
+
+This sample demonstrates how to run ADK agents with a Supabase-backed
+session store and interact with them from a React frontend.
+
+## Files
+
+- `agent.py` – defines a simple multi-agent team.
+- `server.py` – FastAPI app exposing the agents with Supabase persistence.
+- `frontend/src/App.jsx` – React component streaming agent replies.
+
+## Running the Backend
+
+1. Install dependencies:
+   ```bash
+   pip install google-adk uvicorn asyncpg
+   ```
+2. Start the server:
+   ```bash
+   uvicorn contributing.samples.react_supabase.server:app --reload
+   ```
+
+Update `server.py` with your Supabase connection string.
+
+## Running the Frontend
+
+Use your preferred React tooling to bundle `App.jsx`.
+The component connects to `/run_sse` and streams responses
+from the agents as they arrive.

--- a/contributing/samples/react_supabase/__init__.py
+++ b/contributing/samples/react_supabase/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import agent

--- a/contributing/samples/react_supabase/agent.py
+++ b/contributing/samples/react_supabase/agent.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from google.adk.agents import Agent
+
+
+# Simple multi-agent hierarchy used by the React + Supabase demo.
+
+greeter = Agent(
+    name="greeter",
+    model="gemini-2.0-flash",
+    instruction="Greet users when asked.",
+)
+
+task_executor = Agent(
+    name="task_executor",
+    model="gemini-2.0-flash",
+    instruction="Perform tasks delegated by the coordinator.",
+)
+
+root_agent = Agent(
+    name="coordinator",
+    model="gemini-2.0-flash",
+    description="Orchestrates greetings and tasks.",
+    sub_agents=[greeter, task_executor],
+)

--- a/contributing/samples/react_supabase/frontend/src/App.jsx
+++ b/contributing/samples/react_supabase/frontend/src/App.jsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+const API_URL = 'http://localhost:8000';
+const SESSION = { app_name: 'coordinator', user_id: 'demo', session_id: '1' };
+
+export default function App() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    const es = new EventSource(`${API_URL}/run_sse`);
+    es.onmessage = (e) => setMessages((m) => [...m, e.data]);
+    return () => es.close();
+  }, []);
+
+  const send = async () => {
+    await fetch(`${API_URL}/run_sse`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...SESSION, new_message: input }),
+    });
+  };
+
+  return (
+    <div>
+      <ul>
+        {messages.map((m, i) => (
+          <li key={i}>{m}</li>
+        ))}
+      </ul>
+      <input value={input} onChange={(e) => setInput(e.target.value)} />
+      <button onClick={send}>Send</button>
+    </div>
+  );
+}

--- a/contributing/samples/react_supabase/server.py
+++ b/contributing/samples/react_supabase/server.py
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from google.adk.cli.fast_api import get_fast_api_app
+
+
+# FastAPI app exposing the demo agents with Supabase persistence.
+app = get_fast_api_app(
+    agents_dir="contributing/samples/react_supabase",
+    allow_origins=["http://localhost:3000"],
+    web=False,
+    session_service_uri=(
+        "postgresql+asyncpg://USER:PASSWORD@db.supabase.co/db_name"
+    ),
+)


### PR DESCRIPTION
## Summary
- add React and Supabase integration sample
- show minimal multi-agent team
- expose FastAPI server with Supabase session store
- demo React client for streaming agent messages

## Testing
- `./autoformat.sh` *(fails: pyink not found)*
- `pytest tests/unittests` *(fails: 115 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686cd214dd7483208b8080e20236ca07