### PR TITLE
Add semantic memory query with embeddings

### DIFF
--- a/contributing/samples/memcube_system/__init__.py
+++ b/contributing/samples/memcube_system/__init__.py
@@ -15,10 +15,11 @@ from .models import (
     InsightCard
 )
 
-from .storage import (
-    MemCubeStorage,
-    SupabaseMemCubeStorage
-)
+from .storage import MemCubeStorage
+try:  # Optional dependency
+  from .storage import SupabaseMemCubeStorage
+except Exception:  # pragma: no cover - ignore if supabase missing
+  SupabaseMemCubeStorage = None
 
 from .operator import (
     MemoryOperator,

--- a/contributing/samples/memcube_system/embedding.py
+++ b/contributing/samples/memcube_system/embedding.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import numpy as np
+
+_ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
+
+
+def compute_embedding(text: str) -> list[float]:
+  """Compute a simple character frequency embedding."""
+  vec = [0.0] * len(_ALPHABET)
+  for ch in text.lower():
+    idx = _ALPHABET.find(ch)
+    if idx >= 0:
+      vec[idx] += 1
+  arr = np.array(vec, dtype=np.float32)
+  norm = np.linalg.norm(arr)
+  if norm:
+    arr /= norm
+  return arr.tolist()

--- a/contributing/samples/memcube_system/in_memory_storage.py
+++ b/contributing/samples/memcube_system/in_memory_storage.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import faiss
+import numpy as np
+
+from .embedding import compute_embedding
+from .models import MemCube
+from .models import MemoryPriority
+from .models import MemoryQuery
+from .storage import MemCubeStorage
+
+
+class InMemoryMemCubeStorage(MemCubeStorage):
+  """Simple in-memory storage for testing."""
+
+  def __init__(self):
+    self.memories: Dict[str, MemCube] = {}
+
+  async def store_memory(self, memory: MemCube) -> str:
+    self.memories[memory.id] = memory
+    return memory.id
+
+  async def get_memory(self, memory_id: str) -> Optional[MemCube]:
+    return self.memories.get(memory_id)
+
+  async def query_memories(self, query: MemoryQuery) -> List[MemCube]:
+    mems = [
+        m
+        for m in self.memories.values()
+        if m.header.project_id == query.project_id
+    ]
+    if query.type_filter:
+      mems = [m for m in mems if m.type == query.type_filter]
+    if query.priority_filter:
+      mems = [m for m in mems if m.header.priority == query.priority_filter]
+    if query.tags:
+      mems = [m for m in mems if any(t in m.label for t in query.tags)]
+
+    if query.query_text and not query.embedding:
+      query.embedding = compute_embedding(query.query_text)
+
+    if query.embedding:
+      vecs = []
+      mem_list = []
+      for m in mems:
+        if m.header.embedding_sig:
+          vecs.append(np.array(m.header.embedding_sig, dtype='float32'))
+          mem_list.append(m)
+      if vecs:
+        index = faiss.IndexFlatIP(len(query.embedding))
+        index.add(np.vstack(vecs))
+        scores, idxs = index.search(
+            np.array([query.embedding], dtype='float32'),
+            min(query.limit, len(vecs)),
+        )
+        results = []
+        for score, idx in zip(scores[0], idxs[0]):
+          if score < query.similarity_threshold:
+            continue
+          results.append(mem_list[idx])
+          if len(results) >= query.limit:
+            break
+        mems = results
+      else:
+        mems = mem_list[: query.limit]
+    return mems[: query.limit]
+
+  async def update_memory_usage(self, memory_id: str) -> None:
+    pass
+
+  async def archive_memory(self, memory_id: str) -> bool:
+    return self.memories.pop(memory_id, None) is not None

--- a/contributing/samples/memcube_system/models.py
+++ b/contributing/samples/memcube_system/models.py
@@ -1,245 +1,267 @@
 """Core data models for MemCube memory system."""
 
-from typing import Dict, Any, List, Optional, Union
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from pydantic import BaseModel, Field, validator
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
 import uuid
-from dataclasses import dataclass
+
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import validator
 
 
 class MemoryType(str, Enum):
-    """Types of memory cubes matching MemOS taxonomy."""
-    PLAINTEXT = "PLAINTEXT"      # Markdown or JSON ≤ 64KB
-    ACTIVATION = "ACTIVATION"    # Base64-encoded KV cache ≤ 256KB
-    PARAMETER = "PARAMETER"      # LoRA delta patch (compressed)
+  """Types of memory cubes matching MemOS taxonomy."""
+
+  PLAINTEXT = "PLAINTEXT"  # Markdown or JSON ≤ 64KB
+  ACTIVATION = "ACTIVATION"  # Base64-encoded KV cache ≤ 256KB
+  PARAMETER = "PARAMETER"  # LoRA delta patch (compressed)
 
 
 class MemoryLifecycle(str, Enum):
-    """Lifecycle states for memory cubes."""
-    NEW = "NEW"
-    ACTIVE = "ACTIVE"
-    STALE = "STALE"
-    ARCHIVED = "ARCHIVED"
-    EXPIRED = "EXPIRED"
+  """Lifecycle states for memory cubes."""
+
+  NEW = "NEW"
+  ACTIVE = "ACTIVE"
+  STALE = "STALE"
+  ARCHIVED = "ARCHIVED"
+  EXPIRED = "EXPIRED"
 
 
 class MemoryPriority(str, Enum):
-    """Priority levels for memory scheduling."""
-    HOT = "hot"
-    WARM = "warm"
-    COLD = "cold"
+  """Priority levels for memory scheduling."""
+
+  HOT = "hot"
+  WARM = "warm"
+  COLD = "cold"
 
 
 class StorageMode(str, Enum):
-    """Storage modes for memory payloads."""
-    INLINE = "inline"
-    COMPRESSED = "compressed"
-    COLD = "cold"
+  """Storage modes for memory payloads."""
+
+  INLINE = "inline"
+  COMPRESSED = "compressed"
+  COLD = "cold"
 
 
 @dataclass
 class MemoryGovernance:
-    """Governance settings for memory access and lifecycle."""
-    read_roles: List[str] = Field(default_factory=lambda: ["MEMBER"])
-    write_roles: List[str] = Field(default_factory=lambda: ["AGENT"])
-    ttl_days: int = 365
-    shareable: bool = True
-    license: Optional[str] = None  # SPDX identifier
-    pii_tagged: bool = False
-    
+  """Governance settings for memory access and lifecycle."""
+
+  read_roles: List[str] = Field(default_factory=lambda: ["MEMBER"])
+  write_roles: List[str] = Field(default_factory=lambda: ["AGENT"])
+  ttl_days: int = 365
+  shareable: bool = True
+  license: Optional[str] = None  # SPDX identifier
+  pii_tagged: bool = False
+
 
 class MemCubeHeader(BaseModel):
-    """Header metadata for a memory cube."""
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    project_id: str
-    label: str
-    type: MemoryType
-    version: int = 1
-    origin: Optional[str] = None  # e.g., "agent_run:xyz"
-    created_by: str  # agent_id or member_id
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    embedding_sig: Optional[List[float]] = None  # Vector embedding
-    governance: MemoryGovernance = Field(default_factory=MemoryGovernance)
-    
-    # v0.2 extensions
-    usage_hits: int = 0
-    last_used: Optional[datetime] = None
-    priority: MemoryPriority = MemoryPriority.WARM
-    storage_mode: StorageMode = StorageMode.INLINE
-    provenance_id: Optional[str] = None  # First ancestor
-    kv_hint: bool = False  # True if should be injected via KV cache
-    watermark: bool = False
-    
-    class Config:
-        json_encoders = {
-            datetime: lambda v: v.isoformat()
-        }
+  """Header metadata for a memory cube."""
+
+  id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+  project_id: str
+  label: str
+  type: MemoryType
+  version: int = 1
+  origin: Optional[str] = None  # e.g., "agent_run:xyz"
+  created_by: str  # agent_id or member_id
+  created_at: datetime = Field(default_factory=datetime.utcnow)
+  embedding_sig: Optional[List[float]] = None  # Vector embedding
+  governance: MemoryGovernance = Field(default_factory=MemoryGovernance)
+
+  # v0.2 extensions
+  usage_hits: int = 0
+  last_used: Optional[datetime] = None
+  priority: MemoryPriority = MemoryPriority.WARM
+  storage_mode: StorageMode = StorageMode.INLINE
+  provenance_id: Optional[str] = None  # First ancestor
+  kv_hint: bool = False  # True if should be injected via KV cache
+  watermark: bool = False
+
+  class Config:
+    json_encoders = {datetime: lambda v: v.isoformat()}
 
 
 class MemCubePayload(BaseModel):
-    """Payload content for a memory cube."""
-    type: MemoryType
-    content: Union[str, bytes, Dict[str, Any]]
-    token_count: Optional[int] = None
-    size_bytes: int = 0
-    
-    @validator('content')
-    def validate_content_size(cls, v, values):
-        """Validate content size based on type."""
-        mem_type = values.get('type')
-        if mem_type == MemoryType.PLAINTEXT:
-            if isinstance(v, str) and len(v.encode()) > 64 * 1024:
-                raise ValueError("PLAINTEXT content exceeds 64KB limit")
-        elif mem_type == MemoryType.ACTIVATION:
-            if isinstance(v, (str, bytes)) and len(v) > 256 * 1024:
-                raise ValueError("ACTIVATION content exceeds 256KB limit")
-        return v
-        
-    def get_size(self) -> int:
-        """Calculate payload size in bytes."""
-        if isinstance(self.content, str):
-            return len(self.content.encode())
-        elif isinstance(self.content, bytes):
-            return len(self.content)
-        else:
-            return len(str(self.content).encode())
+  """Payload content for a memory cube."""
+
+  type: MemoryType
+  content: Union[str, bytes, Dict[str, Any]]
+  token_count: Optional[int] = None
+  size_bytes: int = 0
+
+  @validator("content")
+  def validate_content_size(cls, v, values):
+    """Validate content size based on type."""
+    mem_type = values.get("type")
+    if mem_type == MemoryType.PLAINTEXT:
+      if isinstance(v, str) and len(v.encode()) > 64 * 1024:
+        raise ValueError("PLAINTEXT content exceeds 64KB limit")
+    elif mem_type == MemoryType.ACTIVATION:
+      if isinstance(v, (str, bytes)) and len(v) > 256 * 1024:
+        raise ValueError("ACTIVATION content exceeds 256KB limit")
+    return v
+
+  def get_size(self) -> int:
+    """Calculate payload size in bytes."""
+    if isinstance(self.content, str):
+      return len(self.content.encode())
+    elif isinstance(self.content, bytes):
+      return len(self.content)
+    else:
+      return len(str(self.content).encode())
 
 
 class MemCube(BaseModel):
-    """Complete memory cube with header and payload."""
-    header: MemCubeHeader
-    payload: MemCubePayload
-    
-    @property
-    def id(self) -> str:
-        return self.header.id
-        
-    @property
-    def label(self) -> str:
-        return self.header.label
-        
-    @property
-    def type(self) -> MemoryType:
-        return self.header.type
-        
-    def to_prompt_text(self) -> str:
-        """Convert to text format for agent prompts."""
-        if self.type == MemoryType.PLAINTEXT:
-            return f"<<MEM:{self.label}>>\n{self.payload.content}\n<<ENDMEM>>"
-        else:
-            return f"<<MEM:{self.label}>>Binary content ({self.type.value})<<ENDMEM>>"
+  """Complete memory cube with header and payload."""
+
+  header: MemCubeHeader
+  payload: MemCubePayload
+
+  @property
+  def id(self) -> str:
+    return self.header.id
+
+  @property
+  def label(self) -> str:
+    return self.header.label
+
+  @property
+  def type(self) -> MemoryType:
+    return self.header.type
+
+  def to_prompt_text(self) -> str:
+    """Convert to text format for agent prompts."""
+    if self.type == MemoryType.PLAINTEXT:
+      return f"<<MEM:{self.label}>>\n{self.payload.content}\n<<ENDMEM>>"
+    else:
+      return f"<<MEM:{self.label}>>Binary content ({self.type.value})<<ENDMEM>>"
 
 
 class MemoryVersion(BaseModel):
-    """Version information for a memory cube."""
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    memory_id: str
-    version: int
-    blob_path: Optional[str] = None
-    vector_sig: Optional[List[float]] = None
-    token_count: int = 0
-    created_by: str
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    kv_hint: bool = False
-    provenance_id: Optional[str] = None
+  """Version information for a memory cube."""
+
+  id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+  memory_id: str
+  version: int
+  blob_path: Optional[str] = None
+  vector_sig: Optional[List[float]] = None
+  token_count: int = 0
+  created_by: str
+  created_at: datetime = Field(default_factory=datetime.utcnow)
+  kv_hint: bool = False
+  provenance_id: Optional[str] = None
 
 
 class MemoryEvent(BaseModel):
-    """Audit event for memory state transitions."""
-    id: Optional[int] = None
-    memory_id: str
-    event: str  # CREATED, PROMOTED, ARCHIVED, EXPIRED, etc.
-    actor: str  # agent or member ID
-    ts: datetime = Field(default_factory=datetime.utcnow)
-    meta: Dict[str, Any] = Field(default_factory=dict)
+  """Audit event for memory state transitions."""
+
+  id: Optional[int] = None
+  memory_id: str
+  event: str  # CREATED, PROMOTED, ARCHIVED, EXPIRED, etc.
+  actor: str  # agent or member ID
+  ts: datetime = Field(default_factory=datetime.utcnow)
+  meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 class MemoryLink(BaseModel):
-    """Link between tasks and memories."""
-    task_id: str
-    memory_id: str
-    role: str = "READ"  # READ or WRITE
+  """Link between tasks and memories."""
+
+  task_id: str
+  memory_id: str
+  role: str = "READ"  # READ or WRITE
 
 
 class MemoryPack(BaseModel):
-    """Collection of memory cubes for distribution."""
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    author_id: str
-    title: str
-    description: str
-    cover_img: Optional[str] = None
-    price_cents: int = 0
-    royalty_pct: int = Field(0, ge=0, le=100)
-    watermark: bool = True
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    memory_ids: List[str] = Field(default_factory=list)
-    
-    @property
-    def is_free(self) -> bool:
-        return self.price_cents == 0
+  """Collection of memory cubes for distribution."""
+
+  id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+  author_id: str
+  title: str
+  description: str
+  cover_img: Optional[str] = None
+  price_cents: int = 0
+  royalty_pct: int = Field(0, ge=0, le=100)
+  watermark: bool = True
+  created_at: datetime = Field(default_factory=datetime.utcnow)
+  memory_ids: List[str] = Field(default_factory=list)
+
+  @property
+  def is_free(self) -> bool:
+    return self.price_cents == 0
 
 
 class InsightCard(BaseModel):
-    """User insight card for crowd-sourced feedback."""
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    insight: str
-    evidence_refs: List[str] = Field(default_factory=list)
-    support_count: int = 0
-    sentiment: float = Field(0.0, ge=-1.0, le=1.0)
-    priority: MemoryPriority = MemoryPriority.WARM
-    tags: List[str] = Field(default_factory=list)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    
-    def to_memcube(self, project_id: str, created_by: str) -> MemCube:
-        """Convert insight card to a memory cube."""
-        header = MemCubeHeader(
-            project_id=project_id,
-            label=f"insight::{self.id[:8]}",
-            type=MemoryType.PLAINTEXT,
-            created_by=created_by,
-            priority=self.priority,
-            governance=MemoryGovernance(
-                read_roles=["MEMBER", "AGENT"],
-                write_roles=["SYSTEM"]
-            )
-        )
-        
-        content = {
-            "insight": self.insight,
-            "support_count": self.support_count,
-            "sentiment": self.sentiment,
-            "evidence_refs": self.evidence_refs,
-            "tags": self.tags
-        }
-        
-        payload = MemCubePayload(
-            type=MemoryType.PLAINTEXT,
-            content=str(content),
-            token_count=len(self.insight.split())  # Simple approximation
-        )
-        
-        return MemCube(header=header, payload=payload)
+  """User insight card for crowd-sourced feedback."""
+
+  id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+  insight: str
+  evidence_refs: List[str] = Field(default_factory=list)
+  support_count: int = 0
+  sentiment: float = Field(0.0, ge=-1.0, le=1.0)
+  priority: MemoryPriority = MemoryPriority.WARM
+  tags: List[str] = Field(default_factory=list)
+  created_at: datetime = Field(default_factory=datetime.utcnow)
+
+  def to_memcube(self, project_id: str, created_by: str) -> MemCube:
+    """Convert insight card to a memory cube."""
+    header = MemCubeHeader(
+        project_id=project_id,
+        label=f"insight::{self.id[:8]}",
+        type=MemoryType.PLAINTEXT,
+        created_by=created_by,
+        priority=self.priority,
+        governance=MemoryGovernance(
+            read_roles=["MEMBER", "AGENT"], write_roles=["SYSTEM"]
+        ),
+    )
+
+    content = {
+        "insight": self.insight,
+        "support_count": self.support_count,
+        "sentiment": self.sentiment,
+        "evidence_refs": self.evidence_refs,
+        "tags": self.tags,
+    }
+
+    payload = MemCubePayload(
+        type=MemoryType.PLAINTEXT,
+        content=str(content),
+        token_count=len(self.insight.split()),  # Simple approximation
+    )
+
+    return MemCube(header=header, payload=payload)
 
 
 class MemoryQuery(BaseModel):
-    """Query parameters for memory search."""
-    project_id: str
-    tags: List[str] = Field(default_factory=list)
-    type_filter: Optional[MemoryType] = None
-    embedding: Optional[List[float]] = None
-    similarity_threshold: float = 0.78
-    limit: int = 10
-    include_insights: bool = False
-    priority_filter: Optional[MemoryPriority] = None
-    
-    
+  """Query parameters for memory search."""
+
+  project_id: str
+  tags: List[str] = Field(default_factory=list)
+  type_filter: Optional[MemoryType] = None
+  query_text: Optional[str] = None
+  embedding: Optional[List[float]] = None
+  similarity_threshold: float = 0.78
+  limit: int = 10
+  include_insights: bool = False
+  priority_filter: Optional[MemoryPriority] = None
+
+
 class MemoryScheduleRequest(BaseModel):
-    """Request from agent for memory scheduling."""
-    agent_id: str
-    task_id: str
-    project_id: str
-    need_tags: List[str] = Field(default_factory=list)
-    token_budget: int = 4000
-    prefer_hot: bool = True
-    include_insights: bool = True
+  """Request from agent for memory scheduling."""
+
+  agent_id: str
+  task_id: str
+  project_id: str
+  need_tags: List[str] = Field(default_factory=list)
+  token_budget: int = 4000
+  prefer_hot: bool = True
+  include_insights: bool = True
+  query_text: Optional[str] = None
+  top_k: int = 10

--- a/contributing/samples/memcube_system/operator.py
+++ b/contributing/samples/memcube_system/operator.py
@@ -1,18 +1,30 @@
 """Memory operator and scheduler for intelligent memory management."""
 
 import asyncio
-import logging
-from typing import Dict, Any, List, Optional, Set, Tuple
-from datetime import datetime, timedelta
 from dataclasses import dataclass
-import json
+from datetime import datetime
+from datetime import timedelta
 import hashlib
+import json
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
 
-from .models import (
-    MemCube, MemCubeHeader, MemCubePayload, MemoryType,
-    MemoryPriority, MemoryQuery, MemoryScheduleRequest,
-    InsightCard
-)
+import numpy as np
+
+from .embedding import compute_embedding
+from .models import InsightCard
+from .models import MemCube
+from .models import MemCubeHeader
+from .models import MemCubePayload
+from .models import MemoryPriority
+from .models import MemoryQuery
+from .models import MemoryScheduleRequest
+from .models import MemoryType
 from .storage import MemCubeStorage
 
 logger = logging.getLogger(__name__)
@@ -20,482 +32,538 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class MemoryContext:
-    """Context for memory operations."""
-    agent_id: str
-    task_id: str
-    project_id: str
-    token_budget: int
-    current_tokens: int = 0
-    included_memories: List[str] = None
-    
-    def __post_init__(self):
-        if self.included_memories is None:
-            self.included_memories = []
-            
-    @property
-    def remaining_tokens(self) -> int:
-        return self.token_budget - self.current_tokens
-        
-    def can_fit(self, memory: MemCube) -> bool:
-        """Check if memory fits in remaining budget."""
-        tokens = memory.payload.token_count or 100  # Default estimate
-        return self.current_tokens + tokens <= self.token_budget
+  """Context for memory operations."""
+
+  agent_id: str
+  task_id: str
+  project_id: str
+  token_budget: int
+  current_tokens: int = 0
+  included_memories: List[str] = None
+
+  def __post_init__(self):
+    if self.included_memories is None:
+      self.included_memories = []
+
+  @property
+  def remaining_tokens(self) -> int:
+    return self.token_budget - self.current_tokens
+
+  def can_fit(self, memory: MemCube) -> bool:
+    """Check if memory fits in remaining budget."""
+    tokens = memory.payload.token_count or 100  # Default estimate
+    return self.current_tokens + tokens <= self.token_budget
 
 
 class MemorySelector:
+  """
+  Intelligent memory selection based on relevance and constraints.
+
+  Uses multiple signals:
+  - Tag matching
+  - Recency (last_used)
+  - Frequency (usage_hits)
+  - Priority (hot/warm/cold)
+  - Vector similarity (if available)
+  - Task context
+  """
+
+  def __init__(self, storage: MemCubeStorage):
+    self.storage = storage
+
+  async def select_memories(
+      self, request: MemoryScheduleRequest
+  ) -> List[MemCube]:
     """
-    Intelligent memory selection based on relevance and constraints.
-    
-    Uses multiple signals:
-    - Tag matching
-    - Recency (last_used)
-    - Frequency (usage_hits)
-    - Priority (hot/warm/cold)
-    - Vector similarity (if available)
-    - Task context
+    Select optimal set of memories for agent request.
+
+    Returns memories that fit within token budget.
     """
-    
-    def __init__(self, storage: MemCubeStorage):
-        self.storage = storage
-        
-    async def select_memories(self, request: MemoryScheduleRequest) -> List[MemCube]:
-        """
-        Select optimal set of memories for agent request.
-        
-        Returns memories that fit within token budget.
-        """
-        context = MemoryContext(
-            agent_id=request.agent_id,
-            task_id=request.task_id,
-            project_id=request.project_id,
-            token_budget=request.token_budget
-        )
-        
-        # Get candidate memories
-        candidates = await self._get_candidates(request)
-        
-        # Score and rank memories
-        scored = await self._score_memories(candidates, request)
-        
-        # Select optimal subset within budget
-        selected = self._optimize_selection(scored, context)
-        
-        # Update usage stats
-        for memory in selected:
-            await self.storage.update_memory_usage(memory.id)
-            
-        logger.info(f"Selected {len(selected)} memories for agent {request.agent_id}")
-        return selected
-        
-    async def _get_candidates(self, request: MemoryScheduleRequest) -> List[MemCube]:
-        """Get candidate memories based on request."""
-        # Start with base query
-        query = MemoryQuery(
-            project_id=request.project_id,
-            tags=request.need_tags,
-            include_insights=request.include_insights,
-            limit=50  # Get more than needed for scoring
-        )
-        
-        # Add priority filter if preferring hot
-        if request.prefer_hot:
-            query.priority_filter = MemoryPriority.HOT
-            
-        # Query storage
-        memories = await self.storage.query_memories(query)
-        
-        # If not enough hot memories, get warm ones too
-        if len(memories) < 10 and request.prefer_hot:
-            query.priority_filter = MemoryPriority.WARM
-            warm_memories = await self.storage.query_memories(query)
-            memories.extend(warm_memories)
-            
-        return memories
-        
-    async def _score_memories(self, memories: List[MemCube], 
-                            request: MemoryScheduleRequest) -> List[Tuple[float, MemCube]]:
-        """Score memories based on relevance."""
-        scored = []
-        
-        for memory in memories:
-            score = 0.0
-            
-            # Tag relevance (0-40 points)
-            tag_score = self._compute_tag_relevance(memory, request.need_tags)
-            score += tag_score * 40
-            
-            # Recency (0-20 points)
-            if memory.header.last_used:
-                age_hours = (datetime.utcnow() - memory.header.last_used).total_seconds() / 3600
-                recency_score = max(0, 1 - (age_hours / 168))  # Decay over week
-                score += recency_score * 20
-                
-            # Frequency (0-20 points)
-            freq_score = min(1.0, memory.header.usage_hits / 50)
-            score += freq_score * 20
-            
-            # Priority bonus (0-10 points)
-            if memory.header.priority == MemoryPriority.HOT:
-                score += 10
-            elif memory.header.priority == MemoryPriority.WARM:
-                score += 5
-                
-            # Task context bonus (0-10 points)
-            if await self._is_task_relevant(memory, request.task_id):
-                score += 10
-                
-            scored.append((score, memory))
-            
-        # Sort by score descending
-        scored.sort(key=lambda x: x[0], reverse=True)
-        return scored
-        
-    def _compute_tag_relevance(self, memory: MemCube, need_tags: List[str]) -> float:
-        """Compute tag relevance score."""
-        if not need_tags:
-            return 0.5  # Neutral if no tags specified
-            
-        # Check label for tag matches
-        label_lower = memory.header.label.lower()
-        matches = sum(1 for tag in need_tags if tag.lower() in label_lower)
-        
-        return min(1.0, matches / len(need_tags))
-        
-    async def _is_task_relevant(self, memory: MemCube, task_id: str) -> bool:
-        """Check if memory is linked to task."""
-        # Could query memory_task_links table
-        # For now, check if task_id in label or origin
-        return (task_id in memory.header.label or 
-                (memory.header.origin and task_id in memory.header.origin))
-                
-    def _optimize_selection(self, scored: List[Tuple[float, MemCube]], 
-                          context: MemoryContext) -> List[MemCube]:
-        """
-        Select optimal subset within token budget.
-        
-        Uses greedy algorithm with diversity bonus.
-        """
-        selected = []
-        selected_types = set()
-        
-        for score, memory in scored:
-            if not context.can_fit(memory):
-                continue
-                
-            # Diversity bonus - prefer different types
-            if memory.header.type not in selected_types:
-                score *= 1.2
-                selected_types.add(memory.header.type)
-                
-            # Add to selection
-            selected.append(memory)
-            context.included_memories.append(memory.id)
-            context.current_tokens += memory.payload.token_count or 100
-            
-            # Stop if budget exhausted
-            if context.remaining_tokens < 100:
-                break
-                
-        return selected
+    context = MemoryContext(
+        agent_id=request.agent_id,
+        task_id=request.task_id,
+        project_id=request.project_id,
+        token_budget=request.token_budget,
+    )
+
+    # Get candidate memories
+    candidates = await self._get_candidates(request)
+
+    # Score and rank memories
+    scored = await self._score_memories(candidates, request)
+
+    # Select optimal subset within budget
+    selected = self._optimize_selection(scored, context)
+
+    # Update usage stats
+    for memory in selected:
+      await self.storage.update_memory_usage(memory.id)
+
+    logger.info(
+        f"Selected {len(selected)} memories for agent {request.agent_id}"
+    )
+    return selected
+
+  async def _get_candidates(
+      self, request: MemoryScheduleRequest
+  ) -> List[MemCube]:
+    """Get candidate memories based on request."""
+    # Start with base query
+    query = MemoryQuery(
+        project_id=request.project_id,
+        tags=request.need_tags,
+        include_insights=request.include_insights,
+        limit=request.top_k,
+    )
+
+    if request.query_text:
+      query.query_text = request.query_text
+
+    # Add priority filter if preferring hot
+    if request.prefer_hot:
+      query.priority_filter = MemoryPriority.HOT
+
+    # Query storage
+    memories = await self.storage.query_memories(query)
+
+    # If not enough hot memories, get warm ones too
+    if len(memories) < 10 and request.prefer_hot:
+      query.priority_filter = MemoryPriority.WARM
+      warm_memories = await self.storage.query_memories(query)
+      memories.extend(warm_memories)
+
+    return memories
+
+  async def _score_memories(
+      self, memories: List[MemCube], request: MemoryScheduleRequest
+  ) -> List[Tuple[float, MemCube]]:
+    """Score memories based on relevance."""
+    scored = []
+
+    query_vec: Optional[List[float]] = None
+    if request.query_text:
+      query_vec = compute_embedding(request.query_text)
+
+    for memory in memories:
+      score = 0.0
+
+      # Tag relevance (0-40 points)
+      tag_score = self._compute_tag_relevance(memory, request.need_tags)
+      score += tag_score * 40
+
+      # Recency (0-20 points)
+      if memory.header.last_used:
+        age_hours = (
+            datetime.utcnow() - memory.header.last_used
+        ).total_seconds() / 3600
+        recency_score = max(0, 1 - (age_hours / 168))  # Decay over week
+        score += recency_score * 20
+
+      # Frequency (0-20 points)
+      freq_score = min(1.0, memory.header.usage_hits / 50)
+      score += freq_score * 20
+
+      # Priority bonus (0-10 points)
+      if memory.header.priority == MemoryPriority.HOT:
+        score += 10
+      elif memory.header.priority == MemoryPriority.WARM:
+        score += 5
+
+      if query_vec and memory.header.embedding_sig:
+        sim = self._compute_similarity(query_vec, memory.header.embedding_sig)
+        score += sim * 30
+
+      # Task context bonus (0-10 points)
+      if await self._is_task_relevant(memory, request.task_id):
+        score += 10
+
+      scored.append((score, memory))
+
+    # Sort by score descending
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored
+
+  def _compute_tag_relevance(
+      self, memory: MemCube, need_tags: List[str]
+  ) -> float:
+    """Compute tag relevance score."""
+    if not need_tags:
+      return 0.5  # Neutral if no tags specified
+
+    # Check label for tag matches
+    label_lower = memory.header.label.lower()
+    matches = sum(1 for tag in need_tags if tag.lower() in label_lower)
+
+    return min(1.0, matches / len(need_tags))
+
+  async def _is_task_relevant(self, memory: MemCube, task_id: str) -> bool:
+    """Check if memory is linked to task."""
+    # Could query memory_task_links table
+    # For now, check if task_id in label or origin
+    return task_id in memory.header.label or (
+        memory.header.origin and task_id in memory.header.origin
+    )
+
+  def _compute_similarity(self, vec1: List[float], vec2: List[float]) -> float:
+    """Compute cosine similarity between vectors."""
+    if len(vec1) != len(vec2):
+      return 0.0
+    v1 = np.array(vec1, dtype="float32")
+    v2 = np.array(vec2, dtype="float32")
+    denom = np.linalg.norm(v1) * np.linalg.norm(v2)
+    if denom == 0:
+      return 0.0
+    return float(np.dot(v1, v2) / denom)
+
+  def _optimize_selection(
+      self, scored: List[Tuple[float, MemCube]], context: MemoryContext
+  ) -> List[MemCube]:
+    """
+    Select optimal subset within token budget.
+
+    Uses greedy algorithm with diversity bonus.
+    """
+    selected = []
+    selected_types = set()
+
+    for score, memory in scored:
+      if not context.can_fit(memory):
+        continue
+
+      # Diversity bonus - prefer different types
+      if memory.header.type not in selected_types:
+        score *= 1.2
+        selected_types.add(memory.header.type)
+
+      # Add to selection
+      selected.append(memory)
+      context.included_memories.append(memory.id)
+      context.current_tokens += memory.payload.token_count or 100
+
+      # Stop if budget exhausted
+      if context.remaining_tokens < 100:
+        break
+
+    return selected
 
 
 class MemoryScheduler:
+  """
+  Schedules memory operations across multiple agents.
+
+  Handles:
+  - Memory request queuing
+  - Priority scheduling
+  - Load balancing
+  - Caching
+  """
+
+  def __init__(
+      self,
+      storage: MemCubeStorage,
+      selector: MemorySelector,
+      cache_ttl: int = 300,
+  ):
+    self.storage = storage
+    self.selector = selector
+    self.cache_ttl = cache_ttl
+    self._cache: Dict[str, Tuple[datetime, List[MemCube]]] = {}
+    self._request_queue: asyncio.Queue = asyncio.Queue()
+    self._worker_task: Optional[asyncio.Task] = None
+
+  async def start(self):
+    """Start the scheduler worker."""
+    self._worker_task = asyncio.create_task(self._process_requests())
+    logger.info("Memory scheduler started")
+
+  async def stop(self):
+    """Stop the scheduler."""
+    if self._worker_task:
+      self._worker_task.cancel()
+      try:
+        await self._worker_task
+      except asyncio.CancelledError:
+        pass
+
+  async def schedule_request(
+      self, request: MemoryScheduleRequest
+  ) -> List[MemCube]:
     """
-    Schedules memory operations across multiple agents.
-    
-    Handles:
-    - Memory request queuing
-    - Priority scheduling
-    - Load balancing
-    - Caching
+    Schedule a memory request.
+
+    Returns selected memories for the agent.
     """
-    
-    def __init__(self, storage: MemCubeStorage, selector: MemorySelector,
-                 cache_ttl: int = 300):
-        self.storage = storage
-        self.selector = selector
-        self.cache_ttl = cache_ttl
-        self._cache: Dict[str, Tuple[datetime, List[MemCube]]] = {}
-        self._request_queue: asyncio.Queue = asyncio.Queue()
-        self._worker_task: Optional[asyncio.Task] = None
-        
-    async def start(self):
-        """Start the scheduler worker."""
-        self._worker_task = asyncio.create_task(self._process_requests())
-        logger.info("Memory scheduler started")
-        
-    async def stop(self):
-        """Stop the scheduler."""
-        if self._worker_task:
-            self._worker_task.cancel()
-            try:
-                await self._worker_task
-            except asyncio.CancelledError:
-                pass
-                
-    async def schedule_request(self, request: MemoryScheduleRequest) -> List[MemCube]:
-        """
-        Schedule a memory request.
-        
-        Returns selected memories for the agent.
-        """
-        # Check cache first
-        cache_key = self._get_cache_key(request)
-        if cache_key in self._cache:
-            cached_time, memories = self._cache[cache_key]
-            if datetime.utcnow() - cached_time < timedelta(seconds=self.cache_ttl):
-                logger.debug(f"Cache hit for {request.agent_id}")
-                return memories
-                
-        # Process request
-        memories = await self.selector.select_memories(request)
-        
-        # Update cache
-        self._cache[cache_key] = (datetime.utcnow(), memories)
-        
-        # Clean old cache entries periodically
-        if len(self._cache) > 1000:
-            await self._clean_cache()
-            
+    # Check cache first
+    cache_key = self._get_cache_key(request)
+    if cache_key in self._cache:
+      cached_time, memories = self._cache[cache_key]
+      if datetime.utcnow() - cached_time < timedelta(seconds=self.cache_ttl):
+        logger.debug(f"Cache hit for {request.agent_id}")
         return memories
-        
-    def _get_cache_key(self, request: MemoryScheduleRequest) -> str:
-        """Generate cache key for request."""
-        key_parts = [
-            request.project_id,
-            request.agent_id,
-            str(sorted(request.need_tags)),
-            str(request.token_budget),
-            str(request.prefer_hot)
-        ]
-        key_str = "|".join(key_parts)
-        return hashlib.md5(key_str.encode()).hexdigest()
-        
-    async def _clean_cache(self):
-        """Remove expired cache entries."""
-        now = datetime.utcnow()
-        expired = []
-        
-        for key, (cached_time, _) in self._cache.items():
-            if now - cached_time > timedelta(seconds=self.cache_ttl):
-                expired.append(key)
-                
-        for key in expired:
-            del self._cache[key]
-            
-        logger.debug(f"Cleaned {len(expired)} expired cache entries")
-        
-    async def _process_requests(self):
-        """Process queued requests."""
-        while True:
-            try:
-                # Process requests with priority
-                await asyncio.sleep(0.1)  # Small delay
-                
-            except asyncio.CancelledError:
-                break
-            except Exception as e:
-                logger.error(f"Error in scheduler worker: {e}")
+
+    # Process request
+    memories = await self.selector.select_memories(request)
+
+    # Update cache
+    self._cache[cache_key] = (datetime.utcnow(), memories)
+
+    # Clean old cache entries periodically
+    if len(self._cache) > 1000:
+      await self._clean_cache()
+
+    return memories
+
+  def _get_cache_key(self, request: MemoryScheduleRequest) -> str:
+    """Generate cache key for request."""
+    key_parts = [
+        request.project_id,
+        request.agent_id,
+        str(sorted(request.need_tags)),
+        str(request.token_budget),
+        str(request.prefer_hot),
+    ]
+    key_str = "|".join(key_parts)
+    return hashlib.md5(key_str.encode()).hexdigest()
+
+  async def _clean_cache(self):
+    """Remove expired cache entries."""
+    now = datetime.utcnow()
+    expired = []
+
+    for key, (cached_time, _) in self._cache.items():
+      if now - cached_time > timedelta(seconds=self.cache_ttl):
+        expired.append(key)
+
+    for key in expired:
+      del self._cache[key]
+
+    logger.debug(f"Cleaned {len(expired)} expired cache entries")
+
+  async def _process_requests(self):
+    """Process queued requests."""
+    while True:
+      try:
+        # Process requests with priority
+        await asyncio.sleep(0.1)  # Small delay
+
+      except asyncio.CancelledError:
+        break
+      except Exception as e:
+        logger.error(f"Error in scheduler worker: {e}")
 
 
 class MemoryOperator:
+  """
+  High-level memory operations and management.
+
+  Provides:
+  - Memory creation helpers
+  - Batch operations
+  - Memory synthesis
+  - Insight processing
+  """
+
+  def __init__(self, storage: MemCubeStorage):
+    self.storage = storage
+
+  async def create_from_text(
+      self,
+      project_id: str,
+      label: str,
+      content: str,
+      created_by: str,
+      tags: Optional[List[str]] = None,
+  ) -> MemCube:
+    """Create a plaintext memory from text content."""
+    # Create header
+    header = MemCubeHeader(
+        project_id=project_id,
+        label=label,
+        type=MemoryType.PLAINTEXT,
+        created_by=created_by,
+        priority=MemoryPriority.WARM,
+        embedding_sig=compute_embedding(content),
+    )
+
+    # Create payload
+    payload = MemCubePayload(
+        type=MemoryType.PLAINTEXT,
+        content=content,
+        token_count=len(content.split()),  # Simple estimate
+    )
+
+    # Create and store
+    memory = MemCube(header=header, payload=payload)
+    await self.storage.store_memory(memory)
+
+    return memory
+
+  async def create_from_activation(
+      self,
+      project_id: str,
+      label: str,
+      kv_cache: bytes,
+      created_by: str,
+      model_hint: str = "",
+  ) -> MemCube:
+    """Create an activation memory from KV cache."""
+    # Create header with KV hint
+    header = MemCubeHeader(
+        project_id=project_id,
+        label=f"{label}::{model_hint}",
+        type=MemoryType.ACTIVATION,
+        created_by=created_by,
+        kv_hint=True,
+        priority=MemoryPriority.HOT,  # Activations usually hot
+    )
+
+    # Create payload
+    payload = MemCubePayload(
+        type=MemoryType.ACTIVATION, content=kv_cache, size_bytes=len(kv_cache)
+    )
+
+    # Create and store
+    memory = MemCube(header=header, payload=payload)
+    await self.storage.store_memory(memory)
+
+    return memory
+
+  async def create_from_insight(
+      self, project_id: str, insight_card: InsightCard, created_by: str
+  ) -> MemCube:
+    """Convert insight card to memory."""
+    memory = insight_card.to_memcube(project_id, created_by)
+    await self.storage.store_memory(memory)
+    return memory
+
+  async def synthesize_memories(
+      self,
+      project_id: str,
+      source_memories: List[MemCube],
+      synthesis_prompt: str,
+      created_by: str,
+  ) -> MemCube:
     """
-    High-level memory operations and management.
-    
-    Provides:
-    - Memory creation helpers
-    - Batch operations
-    - Memory synthesis
-    - Insight processing
+    Synthesize multiple memories into a new one.
+
+    This would typically call an LLM to create a summary.
     """
-    
-    def __init__(self, storage: MemCubeStorage):
-        self.storage = storage
-        
-    async def create_from_text(self, project_id: str, label: str,
-                              content: str, created_by: str,
-                              tags: Optional[List[str]] = None) -> MemCube:
-        """Create a plaintext memory from text content."""
-        # Create header
-        header = MemCubeHeader(
-            project_id=project_id,
-            label=label,
-            type=MemoryType.PLAINTEXT,
-            created_by=created_by,
-            priority=MemoryPriority.WARM
-        )
-        
-        # Create payload
-        payload = MemCubePayload(
-            type=MemoryType.PLAINTEXT,
-            content=content,
-            token_count=len(content.split())  # Simple estimate
-        )
-        
-        # Create and store
-        memory = MemCube(header=header, payload=payload)
-        await self.storage.store_memory(memory)
-        
-        return memory
-        
-    async def create_from_activation(self, project_id: str, label: str,
-                                   kv_cache: bytes, created_by: str,
-                                   model_hint: str = "") -> MemCube:
-        """Create an activation memory from KV cache."""
-        # Create header with KV hint
-        header = MemCubeHeader(
-            project_id=project_id,
-            label=f"{label}::{model_hint}",
-            type=MemoryType.ACTIVATION,
-            created_by=created_by,
-            kv_hint=True,
-            priority=MemoryPriority.HOT  # Activations usually hot
-        )
-        
-        # Create payload
-        payload = MemCubePayload(
-            type=MemoryType.ACTIVATION,
-            content=kv_cache,
-            size_bytes=len(kv_cache)
-        )
-        
-        # Create and store
-        memory = MemCube(header=header, payload=payload)
-        await self.storage.store_memory(memory)
-        
-        return memory
-        
-    async def create_from_insight(self, project_id: str, 
-                                insight_card: InsightCard,
-                                created_by: str) -> MemCube:
-        """Convert insight card to memory."""
-        memory = insight_card.to_memcube(project_id, created_by)
-        await self.storage.store_memory(memory)
-        return memory
-        
-    async def synthesize_memories(self, project_id: str,
-                                source_memories: List[MemCube],
-                                synthesis_prompt: str,
-                                created_by: str) -> MemCube:
-        """
-        Synthesize multiple memories into a new one.
-        
-        This would typically call an LLM to create a summary.
-        """
-        # Combine source content
-        source_texts = []
-        for mem in source_memories:
-            if mem.type == MemoryType.PLAINTEXT:
-                source_texts.append(mem.to_prompt_text())
-                
-        combined = "\n\n".join(source_texts)
-        
-        # TODO: Call LLM for synthesis
-        synthesized_content = f"Synthesis of {len(source_memories)} memories:\n{synthesis_prompt}\n\n{combined[:500]}..."
-        
-        # Create synthesized memory
-        header = MemCubeHeader(
-            project_id=project_id,
-            label=f"synthesis::{datetime.utcnow().strftime('%Y%m%d_%H%M')}",
-            type=MemoryType.PLAINTEXT,
-            created_by=created_by,
-            origin=f"synthesis_from_{len(source_memories)}_memories"
-        )
-        
-        payload = MemCubePayload(
-            type=MemoryType.PLAINTEXT,
-            content=synthesized_content,
-            token_count=len(synthesized_content.split())
-        )
-        
-        memory = MemCube(header=header, payload=payload)
-        await self.storage.store_memory(memory)
-        
-        # Link to source memories via provenance
-        if source_memories:
-            memory.header.provenance_id = source_memories[0].id
-            
-        return memory
-        
-    async def batch_create(self, memories: List[MemCube]) -> List[str]:
-        """Batch create multiple memories."""
-        memory_ids = []
-        
-        for memory in memories:
-            try:
-                memory_id = await self.storage.store_memory(memory)
-                memory_ids.append(memory_id)
-            except Exception as e:
-                logger.error(f"Failed to create memory {memory.label}: {e}")
-                
-        return memory_ids
-        
-    async def update_memory_content(self, memory_id: str, 
-                                  new_content: str,
-                                  updated_by: str) -> Optional[MemCube]:
-        """Update memory content (creates new version)."""
-        # Get existing memory
-        existing = await self.storage.get_memory(memory_id)
-        if not existing:
-            return None
-            
-        # Create new version
-        existing.header.version += 1
-        existing.header.created_by = updated_by
-        existing.header.created_at = datetime.utcnow()
-        existing.header.provenance_id = memory_id  # Link to original
-        
-        # Update payload
-        existing.payload.content = new_content
-        existing.payload.token_count = len(new_content.split())
-        
-        # Store as new memory (versioned)
-        new_id = await self.storage.store_memory(existing)
-        existing.header.id = new_id
-        
-        return existing
-        
-    async def get_memory_lineage(self, memory_id: str, 
-                               max_depth: int = 5) -> List[MemCube]:
-        """Get memory lineage (provenance chain)."""
-        lineage = []
-        current_id = memory_id
-        depth = 0
-        
-        while current_id and depth < max_depth:
-            memory = await self.storage.get_memory(current_id)
-            if not memory:
-                break
-                
-            lineage.append(memory)
-            current_id = memory.header.provenance_id
-            depth += 1
-            
-        return lineage
-        
-    async def prune_cold_memories(self, project_id: str,
-                                 keep_count: int = 100) -> int:
-        """Prune cold memories beyond retention limit."""
-        # Query cold memories
-        query = MemoryQuery(
-            project_id=project_id,
-            priority_filter=MemoryPriority.COLD,
-            limit=1000
-        )
-        
-        cold_memories = await self.storage.query_memories(query)
-        
-        # Sort by last_used (oldest first)
-        cold_memories.sort(
-            key=lambda m: m.header.last_used or datetime.min
-        )
-        
-        # Archive oldest beyond keep_count
-        archived = 0
-        if len(cold_memories) > keep_count:
-            for memory in cold_memories[keep_count:]:
-                if await self.storage.archive_memory(memory.id):
-                    archived += 1
-                    
-        logger.info(f"Archived {archived} cold memories from project {project_id}")
-        return archived
+    # Combine source content
+    source_texts = []
+    for mem in source_memories:
+      if mem.type == MemoryType.PLAINTEXT:
+        source_texts.append(mem.to_prompt_text())
+
+    combined = "\n\n".join(source_texts)
+
+    # TODO: Call LLM for synthesis
+    synthesized_content = (
+        "Synthesis of"
+        f" {len(source_memories)} memories:\n{synthesis_prompt}\n\n{combined[:500]}..."
+    )
+
+    # Create synthesized memory
+    header = MemCubeHeader(
+        project_id=project_id,
+        label=f"synthesis::{datetime.utcnow().strftime('%Y%m%d_%H%M')}",
+        type=MemoryType.PLAINTEXT,
+        created_by=created_by,
+        origin=f"synthesis_from_{len(source_memories)}_memories",
+    )
+
+    payload = MemCubePayload(
+        type=MemoryType.PLAINTEXT,
+        content=synthesized_content,
+        token_count=len(synthesized_content.split()),
+    )
+
+    memory = MemCube(header=header, payload=payload)
+    await self.storage.store_memory(memory)
+
+    # Link to source memories via provenance
+    if source_memories:
+      memory.header.provenance_id = source_memories[0].id
+
+    return memory
+
+  async def batch_create(self, memories: List[MemCube]) -> List[str]:
+    """Batch create multiple memories."""
+    memory_ids = []
+
+    for memory in memories:
+      try:
+        memory_id = await self.storage.store_memory(memory)
+        memory_ids.append(memory_id)
+      except Exception as e:
+        logger.error(f"Failed to create memory {memory.label}: {e}")
+
+    return memory_ids
+
+  async def update_memory_content(
+      self, memory_id: str, new_content: str, updated_by: str
+  ) -> Optional[MemCube]:
+    """Update memory content (creates new version)."""
+    # Get existing memory
+    existing = await self.storage.get_memory(memory_id)
+    if not existing:
+      return None
+
+    # Create new version
+    existing.header.version += 1
+    existing.header.created_by = updated_by
+    existing.header.created_at = datetime.utcnow()
+    existing.header.provenance_id = memory_id  # Link to original
+
+    # Update payload
+    existing.payload.content = new_content
+    existing.payload.token_count = len(new_content.split())
+    existing.header.embedding_sig = compute_embedding(new_content)
+
+    # Store as new memory (versioned)
+    new_id = await self.storage.store_memory(existing)
+    existing.header.id = new_id
+
+    return existing
+
+  async def get_memory_lineage(
+      self, memory_id: str, max_depth: int = 5
+  ) -> List[MemCube]:
+    """Get memory lineage (provenance chain)."""
+    lineage = []
+    current_id = memory_id
+    depth = 0
+
+    while current_id and depth < max_depth:
+      memory = await self.storage.get_memory(current_id)
+      if not memory:
+        break
+
+      lineage.append(memory)
+      current_id = memory.header.provenance_id
+      depth += 1
+
+    return lineage
+
+  async def prune_cold_memories(
+      self, project_id: str, keep_count: int = 100
+  ) -> int:
+    """Prune cold memories beyond retention limit."""
+    # Query cold memories
+    query = MemoryQuery(
+        project_id=project_id, priority_filter=MemoryPriority.COLD, limit=1000
+    )
+
+    cold_memories = await self.storage.query_memories(query)
+
+    # Sort by last_used (oldest first)
+    cold_memories.sort(key=lambda m: m.header.last_used or datetime.min)
+
+    # Archive oldest beyond keep_count
+    archived = 0
+    if len(cold_memories) > keep_count:
+      for memory in cold_memories[keep_count:]:
+        if await self.storage.archive_memory(memory.id):
+          archived += 1
+
+    logger.info(f"Archived {archived} cold memories from project {project_id}")
+    return archived

--- a/contributing/samples/memcube_system/service.py
+++ b/contributing/samples/memcube_system/service.py
@@ -1,23 +1,36 @@
 """MemCube API Service - REST endpoints for memory management."""
 
-from typing import Dict, Any, List, Optional
+from contextlib import asynccontextmanager
 from datetime import datetime
 import logging
 import os
-from contextlib import asynccontextmanager
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
-from fastapi import FastAPI, HTTPException, Query, Body, Depends
+from fastapi import Body
+from fastapi import Depends
+from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi import Query
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from pydantic import Field
 import uvicorn
 
-from .models import (
-    MemCube, MemoryType, MemoryQuery, MemoryScheduleRequest,
-    InsightCard, MemoryPriority
-)
-from .storage import SupabaseMemCubeStorage, MemoryLifecycleManager
-from .operator import MemoryOperator, MemoryScheduler, MemorySelector
 from .marketplace import MarketplaceService
+from .models import InsightCard
+from .models import MemCube
+from .models import MemoryPriority
+from .models import MemoryQuery
+from .models import MemoryScheduleRequest
+from .models import MemoryType
+from .operator import MemoryOperator
+from .operator import MemoryScheduler
+from .operator import MemorySelector
+from .storage import MemoryLifecycleManager
+from .storage import SupabaseMemCubeStorage
 
 logger = logging.getLogger(__name__)
 
@@ -37,87 +50,101 @@ lifecycle_manager: Optional[MemoryLifecycleManager] = None
 
 # Request/Response models
 class MemoryCreateRequest(BaseModel):
-    """Request to create a new memory."""
-    project_id: str
-    label: str
-    content: str
-    type: MemoryType = MemoryType.PLAINTEXT
-    created_by: str
-    tags: List[str] = Field(default_factory=list)
-    priority: MemoryPriority = MemoryPriority.WARM
-    governance: Optional[Dict[str, Any]] = None
+  """Request to create a new memory."""
+
+  project_id: str
+  label: str
+  content: str
+  type: MemoryType = MemoryType.PLAINTEXT
+  created_by: str
+  tags: List[str] = Field(default_factory=list)
+  priority: MemoryPriority = MemoryPriority.WARM
+  governance: Optional[Dict[str, Any]] = None
 
 
 class MemoryUpdateRequest(BaseModel):
-    """Request to update memory content."""
-    content: str
-    updated_by: str
+  """Request to update memory content."""
+
+  content: str
+  updated_by: str
+
+
+class MemoryQueryRequest(BaseModel):
+  """Request for querying memories."""
+
+  project_id: str
+  query_text: Optional[str] = None
+  tags: List[str] = Field(default_factory=list)
+  type_filter: Optional[MemoryType] = None
+  priority_filter: Optional[MemoryPriority] = None
+  top_k: int = 10
+  similarity_threshold: float = 0.78
 
 
 class PackCreateRequest(BaseModel):
-    """Request to create a memory pack."""
-    title: str
-    description: str
-    tags: List[str] = Field(default_factory=list)
-    max_memories: int = 50
-    price_cents: int = 0
-    royalty_pct: int = 10
-    cover_img: Optional[str] = None
+  """Request to create a memory pack."""
+
+  title: str
+  description: str
+  tags: List[str] = Field(default_factory=list)
+  max_memories: int = 50
+  price_cents: int = 0
+  royalty_pct: int = 10
+  cover_img: Optional[str] = None
 
 
 class InsightCreateRequest(BaseModel):
-    """Request to create an insight."""
-    insight: str
-    evidence_refs: List[str] = Field(default_factory=list)
-    tags: List[str] = Field(default_factory=list)
-    sentiment: float = Field(0.0, ge=-1.0, le=1.0)
+  """Request to create an insight."""
+
+  insight: str
+  evidence_refs: List[str] = Field(default_factory=list)
+  tags: List[str] = Field(default_factory=list)
+  sentiment: float = Field(0.0, ge=-1.0, le=1.0)
 
 
 # Lifecycle management
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Manage app lifecycle."""
-    global storage, operator, scheduler, marketplace, lifecycle_manager
-    
-    # Startup
-    logger.info("Starting MemCube service...")
-    
-    # Initialize storage
-    storage = SupabaseMemCubeStorage(
-        SUPABASE_URL,
-        SUPABASE_KEY,
-        BLOB_STORAGE_URL
-    )
-    
-    # Initialize components
-    operator = MemoryOperator(storage)
-    selector = MemorySelector(storage)
-    scheduler = MemoryScheduler(storage, selector)
-    marketplace = MarketplaceService(storage, operator, MARKETPLACE_API)
-    lifecycle_manager = MemoryLifecycleManager(storage)
-    
-    # Start scheduler
-    await scheduler.start()
-    
-    logger.info("MemCube service started successfully")
-    
-    yield
-    
-    # Shutdown
-    logger.info("Shutting down MemCube service...")
-    
-    if scheduler:
-        await scheduler.stop()
-        
-    logger.info("MemCube service stopped")
+  """Manage app lifecycle."""
+  global storage, operator, scheduler, marketplace, lifecycle_manager
+
+  # Startup
+  logger.info("Starting MemCube service...")
+
+  # Initialize storage
+  storage = SupabaseMemCubeStorage(SUPABASE_URL, SUPABASE_KEY, BLOB_STORAGE_URL)
+
+  # Initialize components
+  operator = MemoryOperator(storage)
+  selector = MemorySelector(storage)
+  scheduler = MemoryScheduler(storage, selector)
+  marketplace = MarketplaceService(storage, operator, MARKETPLACE_API)
+  lifecycle_manager = MemoryLifecycleManager(storage)
+
+  # Start scheduler
+  await scheduler.start()
+
+  logger.info("MemCube service started successfully")
+
+  yield
+
+  # Shutdown
+  logger.info("Shutting down MemCube service...")
+
+  if scheduler:
+    await scheduler.stop()
+
+  logger.info("MemCube service stopped")
 
 
 # Create FastAPI app
 app = FastAPI(
     title="MemCube Memory Service",
-    description="Structured memory system for AI agents with marketplace integration",
+    description=(
+        "Structured memory system for AI agents with marketplace integration"
+    ),
     version="0.2.0",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 # Add CORS middleware
@@ -133,195 +160,206 @@ app.add_middleware(
 # Health check
 @app.get("/health")
 async def health_check():
-    """Health check endpoint."""
-    return {
-        "status": "healthy",
-        "service": "memcube",
-        "version": "0.2.0",
-        "timestamp": datetime.utcnow().isoformat()
-    }
+  """Health check endpoint."""
+  return {
+      "status": "healthy",
+      "service": "memcube",
+      "version": "0.2.0",
+      "timestamp": datetime.utcnow().isoformat(),
+  }
 
 
 # Memory CRUD operations
 @app.post("/memories", response_model=Dict[str, Any])
 async def create_memory(request: MemoryCreateRequest):
-    """Create a new memory."""
-    try:
-        if request.type == MemoryType.PLAINTEXT:
-            memory = await operator.create_from_text(
-                project_id=request.project_id,
-                label=request.label,
-                content=request.content,
-                created_by=request.created_by,
-                tags=request.tags
-            )
-        else:
-            raise HTTPException(400, "Only PLAINTEXT memories supported via API")
-            
-        # Set custom governance if provided
-        if request.governance:
-            # Update governance settings
-            memory.header.governance.read_roles = request.governance.get(
-                "read_roles", ["MEMBER"]
-            )
-            memory.header.governance.write_roles = request.governance.get(
-                "write_roles", ["AGENT"]
-            )
-            
-        # Set priority
-        memory.header.priority = request.priority
-        
-        # Store memory
-        memory_id = await storage.store_memory(memory)
-        
-        return {
-            "id": memory_id,
-            "label": memory.label,
-            "type": memory.type.value,
-            "created_at": memory.header.created_at.isoformat()
-        }
-        
-    except Exception as e:
-        logger.error(f"Failed to create memory: {e}")
-        raise HTTPException(500, str(e))
+  """Create a new memory."""
+  try:
+    if request.type == MemoryType.PLAINTEXT:
+      memory = await operator.create_from_text(
+          project_id=request.project_id,
+          label=request.label,
+          content=request.content,
+          created_by=request.created_by,
+          tags=request.tags,
+      )
+    else:
+      raise HTTPException(400, "Only PLAINTEXT memories supported via API")
+
+    # Set custom governance if provided
+    if request.governance:
+      # Update governance settings
+      memory.header.governance.read_roles = request.governance.get(
+          "read_roles", ["MEMBER"]
+      )
+      memory.header.governance.write_roles = request.governance.get(
+          "write_roles", ["AGENT"]
+      )
+
+    # Set priority
+    memory.header.priority = request.priority
+
+    # Store memory
+    memory_id = await storage.store_memory(memory)
+
+    return {
+        "id": memory_id,
+        "label": memory.label,
+        "type": memory.type.value,
+        "created_at": memory.header.created_at.isoformat(),
+    }
+
+  except Exception as e:
+    logger.error(f"Failed to create memory: {e}")
+    raise HTTPException(500, str(e))
 
 
 @app.get("/memories/{memory_id}")
 async def get_memory(memory_id: str):
-    """Get a specific memory."""
-    memory = await storage.get_memory(memory_id)
-    if not memory:
-        raise HTTPException(404, f"Memory {memory_id} not found")
-        
-    # Update usage stats
-    await storage.update_memory_usage(memory_id)
-    
-    return {
-        "id": memory.id,
-        "label": memory.label,
-        "type": memory.type.value,
-        "content": memory.to_prompt_text(),
-        "metadata": {
-            "version": memory.header.version,
-            "created_by": memory.header.created_by,
-            "created_at": memory.header.created_at.isoformat(),
-            "usage_hits": memory.header.usage_hits,
-            "priority": memory.header.priority.value
-        }
-    }
+  """Get a specific memory."""
+  memory = await storage.get_memory(memory_id)
+  if not memory:
+    raise HTTPException(404, f"Memory {memory_id} not found")
+
+  # Update usage stats
+  await storage.update_memory_usage(memory_id)
+
+  return {
+      "id": memory.id,
+      "label": memory.label,
+      "type": memory.type.value,
+      "content": memory.to_prompt_text(),
+      "metadata": {
+          "version": memory.header.version,
+          "created_by": memory.header.created_by,
+          "created_at": memory.header.created_at.isoformat(),
+          "usage_hits": memory.header.usage_hits,
+          "priority": memory.header.priority.value,
+      },
+  }
 
 
 @app.put("/memories/{memory_id}")
 async def update_memory(memory_id: str, request: MemoryUpdateRequest):
-    """Update memory content (creates new version)."""
-    updated = await operator.update_memory_content(
-        memory_id=memory_id,
-        new_content=request.content,
-        updated_by=request.updated_by
-    )
-    
-    if not updated:
-        raise HTTPException(404, f"Memory {memory_id} not found")
-        
-    return {
-        "id": updated.id,
-        "version": updated.header.version,
-        "updated_at": updated.header.created_at.isoformat()
-    }
+  """Update memory content (creates new version)."""
+  updated = await operator.update_memory_content(
+      memory_id=memory_id,
+      new_content=request.content,
+      updated_by=request.updated_by,
+  )
+
+  if not updated:
+    raise HTTPException(404, f"Memory {memory_id} not found")
+
+  return {
+      "id": updated.id,
+      "version": updated.header.version,
+      "updated_at": updated.header.created_at.isoformat(),
+  }
 
 
 @app.delete("/memories/{memory_id}")
 async def archive_memory(memory_id: str):
-    """Archive a memory."""
-    success = await storage.archive_memory(memory_id)
-    if not success:
-        raise HTTPException(404, f"Memory {memory_id} not found")
-        
-    return {"status": "archived", "memory_id": memory_id}
+  """Archive a memory."""
+  success = await storage.archive_memory(memory_id)
+  if not success:
+    raise HTTPException(404, f"Memory {memory_id} not found")
+
+  return {"status": "archived", "memory_id": memory_id}
 
 
 # Memory querying
 @app.post("/memories/query")
-async def query_memories(query: MemoryQuery):
-    """Query memories based on criteria."""
-    memories = await storage.query_memories(query)
-    
-    return {
-        "memories": [
-            {
-                "id": m.id,
-                "label": m.label,
-                "type": m.type.value,
-                "priority": m.header.priority.value,
-                "usage_hits": m.header.usage_hits,
-                "preview": m.to_prompt_text()[:200] + "..." if len(m.to_prompt_text()) > 200 else m.to_prompt_text()
-            }
-            for m in memories
-        ],
-        "count": len(memories)
-    }
+async def query_memories(request: MemoryQueryRequest):
+  """Query memories based on criteria."""
+  query = MemoryQuery(
+      project_id=request.project_id,
+      tags=request.tags,
+      type_filter=request.type_filter,
+      priority_filter=request.priority_filter,
+      limit=request.top_k,
+      similarity_threshold=request.similarity_threshold,
+      query_text=request.query_text,
+  )
+  memories = await storage.query_memories(query)
+
+  return {
+      "memories": [
+          {
+              "id": m.id,
+              "label": m.label,
+              "type": m.type.value,
+              "priority": m.header.priority.value,
+              "usage_hits": m.header.usage_hits,
+              "preview": (
+                  m.to_prompt_text()[:200] + "..."
+                  if len(m.to_prompt_text()) > 200
+                  else m.to_prompt_text()
+              ),
+          }
+          for m in memories
+      ],
+      "count": len(memories),
+  }
 
 
 # Memory scheduling for agents
 @app.post("/memories/schedule")
 async def schedule_memories(request: MemoryScheduleRequest):
-    """Schedule memories for an agent."""
-    memories = await scheduler.schedule_request(request)
-    
-    # Format for agent consumption
-    formatted = []
-    total_tokens = 0
-    
-    for memory in memories:
-        formatted.append({
-            "id": memory.id,
-            "label": memory.label,
-            "content": memory.to_prompt_text(),
-            "tokens": memory.payload.token_count or 100
-        })
-        total_tokens += memory.payload.token_count or 100
-        
-    return {
-        "agent_id": request.agent_id,
-        "memories": formatted,
-        "total_tokens": total_tokens,
-        "count": len(memories)
-    }
+  """Schedule memories for an agent."""
+  memories = await scheduler.schedule_request(request)
+
+  # Format for agent consumption
+  formatted = []
+  total_tokens = 0
+
+  for memory in memories:
+    formatted.append({
+        "id": memory.id,
+        "label": memory.label,
+        "content": memory.to_prompt_text(),
+        "tokens": memory.payload.token_count or 100,
+    })
+    total_tokens += memory.payload.token_count or 100
+
+  return {
+      "agent_id": request.agent_id,
+      "memories": formatted,
+      "total_tokens": total_tokens,
+      "count": len(memories),
+  }
 
 
 # Task-memory linking
 @app.post("/memories/{memory_id}/link")
 async def link_memory_to_task(
-    memory_id: str,
-    task_id: str = Body(...),
-    role: str = Body("READ")
+    memory_id: str, task_id: str = Body(...), role: str = Body("READ")
 ):
-    """Link a memory to a task."""
-    success = await storage.link_memory_to_task(memory_id, task_id, role)
-    if not success:
-        raise HTTPException(400, "Failed to link memory to task")
-        
-    return {"status": "linked", "memory_id": memory_id, "task_id": task_id}
+  """Link a memory to a task."""
+  success = await storage.link_memory_to_task(memory_id, task_id, role)
+  if not success:
+    raise HTTPException(400, "Failed to link memory to task")
+
+  return {"status": "linked", "memory_id": memory_id, "task_id": task_id}
 
 
 @app.get("/tasks/{task_id}/memories")
 async def get_task_memories(task_id: str):
-    """Get memories linked to a task."""
-    memories = await storage.get_memories_for_task(task_id)
-    
-    return {
-        "task_id": task_id,
-        "memories": [
-            {
-                "id": m.id,
-                "label": m.label,
-                "type": m.type.value,
-                "content": m.to_prompt_text()
-            }
-            for m in memories
-        ],
-        "count": len(memories)
-    }
+  """Get memories linked to a task."""
+  memories = await storage.get_memories_for_task(task_id)
+
+  return {
+      "task_id": task_id,
+      "memories": [
+          {
+              "id": m.id,
+              "label": m.label,
+              "type": m.type.value,
+              "content": m.to_prompt_text(),
+          }
+          for m in memories
+      ],
+      "count": len(memories),
+  }
 
 
 # Insight management
@@ -329,29 +367,27 @@ async def get_task_memories(task_id: str):
 async def create_insight(
     project_id: str = Query(...),
     created_by: str = Query(...),
-    request: InsightCreateRequest = Body(...)
+    request: InsightCreateRequest = Body(...),
 ):
-    """Create an insight and convert to memory."""
-    # Create insight card
-    insight = InsightCard(
-        insight=request.insight,
-        evidence_refs=request.evidence_refs,
-        tags=request.tags,
-        sentiment=request.sentiment
-    )
-    
-    # Convert to memory
-    memory = await operator.create_from_insight(
-        project_id=project_id,
-        insight_card=insight,
-        created_by=created_by
-    )
-    
-    return {
-        "insight_id": insight.id,
-        "memory_id": memory.id,
-        "created_at": datetime.utcnow().isoformat()
-    }
+  """Create an insight and convert to memory."""
+  # Create insight card
+  insight = InsightCard(
+      insight=request.insight,
+      evidence_refs=request.evidence_refs,
+      tags=request.tags,
+      sentiment=request.sentiment,
+  )
+
+  # Convert to memory
+  memory = await operator.create_from_insight(
+      project_id=project_id, insight_card=insight, created_by=created_by
+  )
+
+  return {
+      "insight_id": insight.id,
+      "memory_id": memory.id,
+      "created_at": datetime.utcnow().isoformat(),
+  }
 
 
 # Marketplace operations
@@ -359,60 +395,53 @@ async def create_insight(
 async def create_memory_pack(
     author_id: str = Query(...),
     project_id: str = Query(...),
-    request: PackCreateRequest = Body(...)
+    request: PackCreateRequest = Body(...),
 ):
-    """Create and publish a memory pack."""
-    try:
-        listing_id = await marketplace.create_and_publish_pack(
-            author_id=author_id,
-            project_id=project_id,
-            pack_config=request.dict()
-        )
-        
-        return {
-            "listing_id": listing_id,
-            "status": "published",
-            "title": request.title
-        }
-        
-    except Exception as e:
-        logger.error(f"Failed to create pack: {e}")
-        raise HTTPException(500, str(e))
+  """Create and publish a memory pack."""
+  try:
+    listing_id = await marketplace.create_and_publish_pack(
+        author_id=author_id, project_id=project_id, pack_config=request.dict()
+    )
+
+    return {
+        "listing_id": listing_id,
+        "status": "published",
+        "title": request.title,
+    }
+
+  except Exception as e:
+    logger.error(f"Failed to create pack: {e}")
+    raise HTTPException(500, str(e))
 
 
 @app.get("/marketplace/search")
 async def search_marketplace(
-    query: str = Query(...),
-    max_price_cents: Optional[int] = Query(None)
+    query: str = Query(...), max_price_cents: Optional[int] = Query(None)
 ):
-    """Search marketplace for memory packs."""
-    packs = await marketplace.importer.search_packs(query, max_price_cents)
-    return {"packs": packs, "count": len(packs)}
+  """Search marketplace for memory packs."""
+  packs = await marketplace.importer.search_packs(query, max_price_cents)
+  return {"packs": packs, "count": len(packs)}
 
 
 @app.post("/marketplace/import/{pack_id}")
 async def import_memory_pack(
-    pack_id: str,
-    project_id: str = Query(...),
-    buyer_id: str = Query(...)
+    pack_id: str, project_id: str = Query(...), buyer_id: str = Query(...)
 ):
-    """Import a memory pack into project."""
-    try:
-        memory_ids = await marketplace.importer.import_pack(
-            pack_id=pack_id,
-            project_id=project_id,
-            buyer_id=buyer_id
-        )
-        
-        return {
-            "pack_id": pack_id,
-            "imported_memories": memory_ids,
-            "count": len(memory_ids)
-        }
-        
-    except Exception as e:
-        logger.error(f"Failed to import pack: {e}")
-        raise HTTPException(500, str(e))
+  """Import a memory pack into project."""
+  try:
+    memory_ids = await marketplace.importer.import_pack(
+        pack_id=pack_id, project_id=project_id, buyer_id=buyer_id
+    )
+
+    return {
+        "pack_id": pack_id,
+        "imported_memories": memory_ids,
+        "count": len(memory_ids),
+    }
+
+  except Exception as e:
+    logger.error(f"Failed to import pack: {e}")
+    raise HTTPException(500, str(e))
 
 
 # Memory synthesis
@@ -421,65 +450,61 @@ async def synthesize_memories(
     project_id: str = Query(...),
     created_by: str = Query(...),
     memory_ids: List[str] = Body(...),
-    prompt: str = Body(...)
+    prompt: str = Body(...),
 ):
-    """Synthesize multiple memories into a new one."""
-    # Get source memories
-    source_memories = []
-    for mid in memory_ids:
-        memory = await storage.get_memory(mid)
-        if memory:
-            source_memories.append(memory)
-            
-    if not source_memories:
-        raise HTTPException(400, "No valid source memories found")
-        
-    # Synthesize
-    synthesized = await operator.synthesize_memories(
-        project_id=project_id,
-        source_memories=source_memories,
-        synthesis_prompt=prompt,
-        created_by=created_by
-    )
-    
-    return {
-        "id": synthesized.id,
-        "label": synthesized.label,
-        "source_count": len(source_memories),
-        "content_preview": synthesized.to_prompt_text()[:500]
-    }
+  """Synthesize multiple memories into a new one."""
+  # Get source memories
+  source_memories = []
+  for mid in memory_ids:
+    memory = await storage.get_memory(mid)
+    if memory:
+      source_memories.append(memory)
+
+  if not source_memories:
+    raise HTTPException(400, "No valid source memories found")
+
+  # Synthesize
+  synthesized = await operator.synthesize_memories(
+      project_id=project_id,
+      source_memories=source_memories,
+      synthesis_prompt=prompt,
+      created_by=created_by,
+  )
+
+  return {
+      "id": synthesized.id,
+      "label": synthesized.label,
+      "source_count": len(source_memories),
+      "content_preview": synthesized.to_prompt_text()[:500],
+  }
 
 
 # Admin operations
 @app.post("/admin/lifecycle")
 async def run_lifecycle_tasks():
-    """Run memory lifecycle management tasks."""
-    if not lifecycle_manager:
-        raise HTTPException(503, "Lifecycle manager not initialized")
-        
-    await lifecycle_manager.run_lifecycle_tasks()
-    return {"status": "completed", "timestamp": datetime.utcnow().isoformat()}
+  """Run memory lifecycle management tasks."""
+  if not lifecycle_manager:
+    raise HTTPException(503, "Lifecycle manager not initialized")
+
+  await lifecycle_manager.run_lifecycle_tasks()
+  return {"status": "completed", "timestamp": datetime.utcnow().isoformat()}
 
 
 @app.post("/admin/prune/{project_id}")
 async def prune_cold_memories(
-    project_id: str,
-    keep_count: int = Query(100, ge=10, le=1000)
+    project_id: str, keep_count: int = Query(100, ge=10, le=1000)
 ):
-    """Prune cold memories for a project."""
-    archived = await operator.prune_cold_memories(project_id, keep_count)
-    return {
-        "project_id": project_id,
-        "archived_count": archived,
-        "keep_count": keep_count
-    }
+  """Prune cold memories for a project."""
+  archived = await operator.prune_cold_memories(project_id, keep_count)
+  return {
+      "project_id": project_id,
+      "archived_count": archived,
+      "keep_count": keep_count,
+  }
 
 
 # Main entry point
 if __name__ == "__main__":
-    uvicorn.run(
-        "memcube_system.service:app",
-        host="0.0.0.0",
-        port=8002,
-        reload=True
-    )
+  uvicorn.run(
+      "memcube_system.service:app", host="0.0.0.0", port=8002, reload=True
+  )

--- a/contributing/samples/memcube_system/storage.py
+++ b/contributing/samples/memcube_system/storage.py
@@ -1,595 +1,676 @@
 """Storage layer for MemCube memory system using Supabase."""
 
-import json
-import base64
 import asyncio
+import base64
+from datetime import datetime
+from datetime import timedelta
+import json
 import logging
-from typing import Dict, Any, List, Optional, Tuple
-from datetime import datetime, timedelta
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
 import aiohttp
-from supabase import create_client, Client
+import faiss
 import numpy as np
 from pydantic import BaseModel
+from supabase import Client
+from supabase import create_client
 
-from .models import (
-    MemCube, MemCubeHeader, MemCubePayload, MemoryType,
-    MemoryLifecycle, MemoryPriority, StorageMode,
-    MemoryVersion, MemoryEvent, MemoryLink, MemoryQuery
-)
+from .embedding import compute_embedding
+from .models import MemCube
+from .models import MemCubeHeader
+from .models import MemCubePayload
+from .models import MemoryEvent
+from .models import MemoryLifecycle
+from .models import MemoryLink
+from .models import MemoryPriority
+from .models import MemoryQuery
+from .models import MemoryType
+from .models import MemoryVersion
+from .models import StorageMode
 
 logger = logging.getLogger(__name__)
 
 
 class MemCubeStorage:
-    """Abstract base class for MemCube storage backends."""
-    
-    async def store_memory(self, memory: MemCube) -> str:
-        """Store a memory cube and return its ID."""
-        raise NotImplementedError
-        
-    async def get_memory(self, memory_id: str) -> Optional[MemCube]:
-        """Retrieve a memory cube by ID."""
-        raise NotImplementedError
-        
-    async def query_memories(self, query: MemoryQuery) -> List[MemCube]:
-        """Query memories based on criteria."""
-        raise NotImplementedError
-        
-    async def update_memory_usage(self, memory_id: str) -> None:
-        """Update usage statistics for a memory."""
-        raise NotImplementedError
-        
-    async def archive_memory(self, memory_id: str) -> bool:
-        """Archive a memory cube."""
-        raise NotImplementedError
+  """Abstract base class for MemCube storage backends."""
+
+  async def store_memory(self, memory: MemCube) -> str:
+    """Store a memory cube and return its ID."""
+    raise NotImplementedError
+
+  async def get_memory(self, memory_id: str) -> Optional[MemCube]:
+    """Retrieve a memory cube by ID."""
+    raise NotImplementedError
+
+  async def query_memories(self, query: MemoryQuery) -> List[MemCube]:
+    """Query memories based on criteria."""
+    raise NotImplementedError
+
+  async def update_memory_usage(self, memory_id: str) -> None:
+    """Update usage statistics for a memory."""
+    raise NotImplementedError
+
+  async def archive_memory(self, memory_id: str) -> bool:
+    """Archive a memory cube."""
+    raise NotImplementedError
 
 
 class SupabaseMemCubeStorage(MemCubeStorage):
+  """
+  Supabase-backed storage for MemCube system.
+
+  Expected Supabase schema:
+  - memories: Core memory table with header data
+  - memory_payloads: Payload storage (can be external)
+  - memory_versions: Version history
+  - memory_events: Audit trail
+  - memory_task_links: Task associations
+  """
+
+  def __init__(
+      self,
+      supabase_url: str,
+      supabase_key: str,
+      blob_storage_url: Optional[str] = None,
+  ):
+    self.client: Client = create_client(supabase_url, supabase_key)
+    self.blob_storage_url = blob_storage_url
+    self._session: Optional[aiohttp.ClientSession] = None
+
+  async def __aenter__(self):
+    self._session = aiohttp.ClientSession()
+    return self
+
+  async def __aexit__(self, exc_type, exc_val, exc_tb):
+    if self._session:
+      await self._session.close()
+
+  async def store_memory(self, memory: MemCube) -> str:
     """
-    Supabase-backed storage for MemCube system.
-    
-    Expected Supabase schema:
-    - memories: Core memory table with header data
-    - memory_payloads: Payload storage (can be external)
-    - memory_versions: Version history
-    - memory_events: Audit trail
-    - memory_task_links: Task associations
+    Store a memory cube in Supabase.
+
+    Splits header and payload for efficient storage.
+    Large payloads go to blob storage.
     """
-    
-    def __init__(self, supabase_url: str, supabase_key: str,
-                 blob_storage_url: Optional[str] = None):
-        self.client: Client = create_client(supabase_url, supabase_key)
-        self.blob_storage_url = blob_storage_url
-        self._session: Optional[aiohttp.ClientSession] = None
-        
-    async def __aenter__(self):
-        self._session = aiohttp.ClientSession()
-        return self
-        
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self._session:
-            await self._session.close()
-            
-    async def store_memory(self, memory: MemCube) -> str:
-        """
-        Store a memory cube in Supabase.
-        
-        Splits header and payload for efficient storage.
-        Large payloads go to blob storage.
-        """
-        try:
-            # Determine storage mode based on size
-            payload_size = memory.payload.get_size()
-            storage_mode = self._determine_storage_mode(payload_size)
-            
-            # Store payload
-            payload_ref = await self._store_payload(
-                memory.id, 
-                memory.payload,
-                storage_mode
-            )
-            
-            # Prepare header data for DB
-            header_data = {
-                "id": memory.header.id,
-                "project_id": memory.header.project_id,
-                "label": memory.header.label,
-                "type": memory.header.type.value,
-                "version": memory.header.version,
-                "origin": memory.header.origin,
-                "created_by": memory.header.created_by,
-                "created_at": memory.header.created_at.isoformat(),
-                "embedding_sig": memory.header.embedding_sig,
-                "governance": json.dumps({
-                    "read_roles": memory.header.governance.read_roles,
-                    "write_roles": memory.header.governance.write_roles,
-                    "ttl_days": memory.header.governance.ttl_days,
-                    "shareable": memory.header.governance.shareable,
-                    "license": memory.header.governance.license,
-                    "pii_tagged": memory.header.governance.pii_tagged
-                }),
-                "usage_hits": memory.header.usage_hits,
-                "last_used": memory.header.last_used.isoformat() if memory.header.last_used else None,
-                "priority": memory.header.priority.value,
-                "storage_mode": storage_mode.value,
-                "provenance_id": memory.header.provenance_id,
-                "kv_hint": memory.header.kv_hint,
-                "watermark": memory.header.watermark,
-                "payload_ref": payload_ref,
-                "size_bytes": payload_size,
-                "token_count": memory.payload.token_count
-            }
-            
-            # Insert into memories table
-            result = self.client.table("memories").insert(header_data).execute()
-            
-            # Create version record
-            version_data = {
-                "memory_id": memory.id,
-                "version": memory.header.version,
-                "blob_path": payload_ref if storage_mode != StorageMode.INLINE else None,
-                "vector_sig": memory.header.embedding_sig,
-                "token_count": memory.payload.token_count or 0,
-                "created_by": memory.header.created_by,
-                "created_at": memory.header.created_at.isoformat(),
-                "kv_hint": memory.header.kv_hint,
-                "provenance_id": memory.header.provenance_id
-            }
-            self.client.table("memory_versions").insert(version_data).execute()
-            
-            # Log creation event
-            await self._log_event(memory.id, "CREATED", memory.header.created_by)
-            
-            logger.info(f"Stored memory {memory.id} with {storage_mode.value} mode")
-            return memory.id
-            
-        except Exception as e:
-            logger.error(f"Failed to store memory: {e}")
-            raise
-            
-    async def get_memory(self, memory_id: str) -> Optional[MemCube]:
-        """Retrieve a memory cube by ID."""
-        try:
-            # Get header from memories table
-            result = self.client.table("memories").select("*").eq("id", memory_id).execute()
-            
-            if not result.data:
-                return None
-                
-            header_data = result.data[0]
-            
-            # Reconstruct governance
-            governance_data = json.loads(header_data["governance"])
-            from dataclasses import dataclass
-            from .models import MemoryGovernance
-            governance = MemoryGovernance(
-                read_roles=governance_data.get("read_roles", ["MEMBER"]),
-                write_roles=governance_data.get("write_roles", ["AGENT"]),
-                ttl_days=governance_data.get("ttl_days", 365),
-                shareable=governance_data.get("shareable", True),
-                license=governance_data.get("license"),
-                pii_tagged=governance_data.get("pii_tagged", False)
-            )
-            
-            # Reconstruct header
-            header = MemCubeHeader(
-                id=header_data["id"],
-                project_id=header_data["project_id"],
-                label=header_data["label"],
-                type=MemoryType(header_data["type"]),
-                version=header_data["version"],
-                origin=header_data["origin"],
-                created_by=header_data["created_by"],
-                created_at=datetime.fromisoformat(header_data["created_at"]),
-                embedding_sig=header_data["embedding_sig"],
-                governance=governance,
-                usage_hits=header_data["usage_hits"],
-                last_used=datetime.fromisoformat(header_data["last_used"]) if header_data["last_used"] else None,
-                priority=MemoryPriority(header_data["priority"]),
-                storage_mode=StorageMode(header_data["storage_mode"]),
-                provenance_id=header_data["provenance_id"],
-                kv_hint=header_data["kv_hint"],
-                watermark=header_data["watermark"]
-            )
-            
-            # Retrieve payload
-            payload = await self._retrieve_payload(
-                memory_id,
-                header_data["payload_ref"],
-                StorageMode(header_data["storage_mode"]),
-                MemoryType(header_data["type"])
-            )
-            
-            if not payload:
-                logger.warning(f"Failed to retrieve payload for memory {memory_id}")
-                return None
-                
-            return MemCube(header=header, payload=payload)
-            
-        except Exception as e:
-            logger.error(f"Failed to get memory {memory_id}: {e}")
-            return None
-            
-    async def query_memories(self, query: MemoryQuery) -> List[MemCube]:
-        """
-        Query memories based on criteria.
-        
-        Supports filtering by:
-        - Project ID
-        - Tags (via JSON search)
-        - Memory type
-        - Priority
-        - Vector similarity (if embeddings available)
-        """
-        try:
-            # Start with base query
-            q = self.client.table("memories").select("*").eq("project_id", query.project_id)
-            
-            # Add type filter
-            if query.type_filter:
-                q = q.eq("type", query.type_filter.value)
-                
-            # Add priority filter
-            if query.priority_filter:
-                q = q.eq("priority", query.priority_filter.value)
-                
-            # Execute query
-            result = q.limit(query.limit * 2).execute()  # Get extra for filtering
-            
-            memories = []
-            for row in result.data:
-                # Tag filtering (if tags stored in label or governance)
-                if query.tags and not self._matches_tags(row, query.tags):
-                    continue
-                    
-                # Vector similarity filtering (if embeddings provided)
-                if query.embedding and row.get("embedding_sig"):
-                    similarity = self._compute_similarity(
-                        query.embedding,
-                        row["embedding_sig"]
-                    )
-                    if similarity < query.similarity_threshold:
-                        continue
-                        
-                # Retrieve full memory
-                memory = await self.get_memory(row["id"])
-                if memory:
-                    memories.append(memory)
-                    
-                if len(memories) >= query.limit:
-                    break
-                    
-            # Include insights if requested
-            if query.include_insights:
-                insights = await self._get_insight_memories(
-                    query.project_id,
-                    query.limit - len(memories)
-                )
-                memories.extend(insights)
-                
-            return memories
-            
-        except Exception as e:
-            logger.error(f"Failed to query memories: {e}")
-            return []
-            
-    async def update_memory_usage(self, memory_id: str) -> None:
-        """Update usage statistics for a memory."""
-        try:
-            # Increment usage counter and update last_used
-            now = datetime.utcnow()
-            
-            result = self.client.table("memories").update({
-                "usage_hits": self.client.rpc("increment", {"value": 1}),
-                "last_used": now.isoformat()
-            }).eq("id", memory_id).execute()
-            
-            # Log access event
-            await self._log_event(memory_id, "ACCESSED", "system")
-            
-            # Check if should promote to HOT
-            if result.data and result.data[0]["usage_hits"] > 10:
-                await self._update_priority(memory_id, MemoryPriority.HOT)
-                
-        except Exception as e:
-            logger.error(f"Failed to update usage for {memory_id}: {e}")
-            
-    async def archive_memory(self, memory_id: str) -> bool:
-        """Archive a memory cube."""
-        try:
-            # Update lifecycle state
-            result = self.client.table("memories").update({
-                "lifecycle": MemoryLifecycle.ARCHIVED.value,
-                "priority": MemoryPriority.COLD.value
-            }).eq("id", memory_id).execute()
-            
-            if result.data:
-                await self._log_event(memory_id, "ARCHIVED", "system")
-                return True
-                
-            return False
-            
-        except Exception as e:
-            logger.error(f"Failed to archive memory {memory_id}: {e}")
-            return False
-            
-    async def link_memory_to_task(self, memory_id: str, task_id: str,
-                                 role: str = "READ") -> bool:
-        """Create a link between memory and task."""
-        try:
-            link_data = {
-                "memory_id": memory_id,
-                "task_id": task_id,
-                "role": role
-            }
-            
-            self.client.table("memory_task_links").insert(link_data).execute()
-            return True
-            
-        except Exception as e:
-            logger.error(f"Failed to link memory {memory_id} to task {task_id}: {e}")
-            return False
-            
-    async def get_memories_for_task(self, task_id: str) -> List[MemCube]:
-        """Get all memories linked to a task."""
-        try:
-            # Get memory IDs linked to task
-            result = self.client.table("memory_task_links")\
-                .select("memory_id")\
-                .eq("task_id", task_id)\
-                .execute()
-                
-            memories = []
-            for link in result.data:
-                memory = await self.get_memory(link["memory_id"])
-                if memory:
-                    memories.append(memory)
-                    
-            return memories
-            
-        except Exception as e:
-            logger.error(f"Failed to get memories for task {task_id}: {e}")
-            return []
-            
-    # Private helper methods
-    
-    def _determine_storage_mode(self, size_bytes: int) -> StorageMode:
-        """Determine storage mode based on payload size."""
-        if size_bytes < 4 * 1024:  # < 4KB
-            return StorageMode.INLINE
-        elif size_bytes < 64 * 1024:  # < 64KB
-            return StorageMode.COMPRESSED
-        else:
-            return StorageMode.COLD
-            
-    async def _store_payload(self, memory_id: str, payload: MemCubePayload,
-                           mode: StorageMode) -> str:
-        """Store payload based on storage mode."""
-        if mode == StorageMode.INLINE:
-            # Store directly in DB as JSON
-            if isinstance(payload.content, str):
-                return payload.content
-            elif isinstance(payload.content, bytes):
-                return base64.b64encode(payload.content).decode()
-            else:
-                return json.dumps(payload.content)
-                
-        elif mode == StorageMode.COMPRESSED:
-            # Compress and store in DB
-            import gzip
-            content_bytes = self._serialize_payload(payload)
-            compressed = gzip.compress(content_bytes)
-            return base64.b64encode(compressed).decode()
-            
-        else:  # COLD storage
-            # Store in blob storage
-            if self.blob_storage_url:
-                return await self._store_to_blob(memory_id, payload)
-            else:
-                # Fallback to compressed storage
-                return await self._store_payload(memory_id, payload, StorageMode.COMPRESSED)
-                
-    async def _retrieve_payload(self, memory_id: str, payload_ref: str,
-                              mode: StorageMode, mem_type: MemoryType) -> Optional[MemCubePayload]:
-        """Retrieve payload based on storage mode."""
-        try:
-            if mode == StorageMode.INLINE:
-                # Direct content
-                if mem_type == MemoryType.PLAINTEXT:
-                    content = payload_ref
-                elif mem_type == MemoryType.ACTIVATION:
-                    content = base64.b64decode(payload_ref)
-                else:
-                    content = json.loads(payload_ref)
-                    
-            elif mode == StorageMode.COMPRESSED:
-                # Decompress
-                import gzip
-                compressed = base64.b64decode(payload_ref)
-                content_bytes = gzip.decompress(compressed)
-                content = self._deserialize_payload(content_bytes, mem_type)
-                
-            else:  # COLD storage
-                # Retrieve from blob
-                if self.blob_storage_url:
-                    content = await self._retrieve_from_blob(memory_id)
-                else:
-                    # Try as compressed
-                    return await self._retrieve_payload(
-                        memory_id, payload_ref, 
-                        StorageMode.COMPRESSED, mem_type
-                    )
-                    
-            return MemCubePayload(
-                type=mem_type,
-                content=content,
-                size_bytes=len(str(content).encode())
-            )
-            
-        except Exception as e:
-            logger.error(f"Failed to retrieve payload: {e}")
-            return None
-            
-    def _serialize_payload(self, payload: MemCubePayload) -> bytes:
-        """Serialize payload to bytes."""
-        if isinstance(payload.content, bytes):
-            return payload.content
-        elif isinstance(payload.content, str):
-            return payload.content.encode()
-        else:
-            return json.dumps(payload.content).encode()
-            
-    def _deserialize_payload(self, data: bytes, mem_type: MemoryType) -> Any:
-        """Deserialize payload from bytes."""
-        if mem_type == MemoryType.ACTIVATION:
-            return data
-        elif mem_type == MemoryType.PLAINTEXT:
-            return data.decode()
-        else:
-            return json.loads(data.decode())
-            
-    async def _store_to_blob(self, memory_id: str, payload: MemCubePayload) -> str:
-        """Store payload to external blob storage."""
-        # Implementation depends on blob storage provider
-        # Return blob path/URL
-        blob_path = f"memories/{memory_id}/v{datetime.utcnow().timestamp()}"
-        # TODO: Actual blob storage implementation
-        return blob_path
-        
-    async def _retrieve_from_blob(self, memory_id: str) -> Any:
-        """Retrieve payload from blob storage."""
-        # TODO: Actual blob retrieval
+    try:
+      # Determine storage mode based on size
+      payload_size = memory.payload.get_size()
+      storage_mode = self._determine_storage_mode(payload_size)
+
+      # Store payload
+      payload_ref = await self._store_payload(
+          memory.id, memory.payload, storage_mode
+      )
+
+      # Prepare header data for DB
+      header_data = {
+          "id": memory.header.id,
+          "project_id": memory.header.project_id,
+          "label": memory.header.label,
+          "type": memory.header.type.value,
+          "version": memory.header.version,
+          "origin": memory.header.origin,
+          "created_by": memory.header.created_by,
+          "created_at": memory.header.created_at.isoformat(),
+          "embedding_sig": memory.header.embedding_sig,
+          "governance": json.dumps({
+              "read_roles": memory.header.governance.read_roles,
+              "write_roles": memory.header.governance.write_roles,
+              "ttl_days": memory.header.governance.ttl_days,
+              "shareable": memory.header.governance.shareable,
+              "license": memory.header.governance.license,
+              "pii_tagged": memory.header.governance.pii_tagged,
+          }),
+          "usage_hits": memory.header.usage_hits,
+          "last_used": (
+              memory.header.last_used.isoformat()
+              if memory.header.last_used
+              else None
+          ),
+          "priority": memory.header.priority.value,
+          "storage_mode": storage_mode.value,
+          "provenance_id": memory.header.provenance_id,
+          "kv_hint": memory.header.kv_hint,
+          "watermark": memory.header.watermark,
+          "payload_ref": payload_ref,
+          "size_bytes": payload_size,
+          "token_count": memory.payload.token_count,
+      }
+
+      # Insert into memories table
+      result = self.client.table("memories").insert(header_data).execute()
+
+      # Create version record
+      version_data = {
+          "memory_id": memory.id,
+          "version": memory.header.version,
+          "blob_path": (
+              payload_ref if storage_mode != StorageMode.INLINE else None
+          ),
+          "vector_sig": memory.header.embedding_sig,
+          "token_count": memory.payload.token_count or 0,
+          "created_by": memory.header.created_by,
+          "created_at": memory.header.created_at.isoformat(),
+          "kv_hint": memory.header.kv_hint,
+          "provenance_id": memory.header.provenance_id,
+      }
+      self.client.table("memory_versions").insert(version_data).execute()
+
+      # Log creation event
+      await self._log_event(memory.id, "CREATED", memory.header.created_by)
+
+      logger.info(f"Stored memory {memory.id} with {storage_mode.value} mode")
+      return memory.id
+
+    except Exception as e:
+      logger.error(f"Failed to store memory: {e}")
+      raise
+
+  async def get_memory(self, memory_id: str) -> Optional[MemCube]:
+    """Retrieve a memory cube by ID."""
+    try:
+      # Get header from memories table
+      result = (
+          self.client.table("memories")
+          .select("*")
+          .eq("id", memory_id)
+          .execute()
+      )
+
+      if not result.data:
         return None
-        
-    def _matches_tags(self, row: Dict[str, Any], tags: List[str]) -> bool:
-        """Check if memory matches required tags."""
-        # Simple implementation - could be enhanced
-        label = row.get("label", "").lower()
-        return any(tag.lower() in label for tag in tags)
-        
-    def _compute_similarity(self, vec1: List[float], vec2: List[float]) -> float:
-        """Compute cosine similarity between vectors."""
-        if len(vec1) != len(vec2):
-            return 0.0
-            
-        v1 = np.array(vec1)
-        v2 = np.array(vec2)
-        
-        dot_product = np.dot(v1, v2)
-        norm_product = np.linalg.norm(v1) * np.linalg.norm(v2)
-        
-        if norm_product == 0:
-            return 0.0
-            
-        return dot_product / norm_product
-        
-    async def _update_priority(self, memory_id: str, priority: MemoryPriority) -> None:
-        """Update memory priority."""
-        try:
-            self.client.table("memories").update({
-                "priority": priority.value
-            }).eq("id", memory_id).execute()
-            
-            await self._log_event(memory_id, f"PRIORITY_CHANGED_{priority.value}", "system")
-            
-        except Exception as e:
-            logger.error(f"Failed to update priority: {e}")
-            
-    async def _log_event(self, memory_id: str, event: str, actor: str,
-                        meta: Optional[Dict[str, Any]] = None) -> None:
-        """Log a memory event."""
-        try:
-            event_data = {
-                "memory_id": memory_id,
-                "event": event,
-                "actor": actor,
-                "ts": datetime.utcnow().isoformat(),
-                "meta": json.dumps(meta or {})
-            }
-            
-            self.client.table("memory_events").insert(event_data).execute()
-            
-        except Exception as e:
-            logger.error(f"Failed to log event: {e}")
-            
-    async def _get_insight_memories(self, project_id: str, limit: int) -> List[MemCube]:
-        """Get insight-based memories."""
-        # TODO: Query insights table and convert to memories
-        return []
+
+      header_data = result.data[0]
+
+      # Reconstruct governance
+      governance_data = json.loads(header_data["governance"])
+      from dataclasses import dataclass
+
+      from .models import MemoryGovernance
+
+      governance = MemoryGovernance(
+          read_roles=governance_data.get("read_roles", ["MEMBER"]),
+          write_roles=governance_data.get("write_roles", ["AGENT"]),
+          ttl_days=governance_data.get("ttl_days", 365),
+          shareable=governance_data.get("shareable", True),
+          license=governance_data.get("license"),
+          pii_tagged=governance_data.get("pii_tagged", False),
+      )
+
+      # Reconstruct header
+      header = MemCubeHeader(
+          id=header_data["id"],
+          project_id=header_data["project_id"],
+          label=header_data["label"],
+          type=MemoryType(header_data["type"]),
+          version=header_data["version"],
+          origin=header_data["origin"],
+          created_by=header_data["created_by"],
+          created_at=datetime.fromisoformat(header_data["created_at"]),
+          embedding_sig=header_data["embedding_sig"],
+          governance=governance,
+          usage_hits=header_data["usage_hits"],
+          last_used=datetime.fromisoformat(header_data["last_used"])
+          if header_data["last_used"]
+          else None,
+          priority=MemoryPriority(header_data["priority"]),
+          storage_mode=StorageMode(header_data["storage_mode"]),
+          provenance_id=header_data["provenance_id"],
+          kv_hint=header_data["kv_hint"],
+          watermark=header_data["watermark"],
+      )
+
+      # Retrieve payload
+      payload = await self._retrieve_payload(
+          memory_id,
+          header_data["payload_ref"],
+          StorageMode(header_data["storage_mode"]),
+          MemoryType(header_data["type"]),
+      )
+
+      if not payload:
+        logger.warning(f"Failed to retrieve payload for memory {memory_id}")
+        return None
+
+      return MemCube(header=header, payload=payload)
+
+    except Exception as e:
+      logger.error(f"Failed to get memory {memory_id}: {e}")
+      return None
+
+  async def query_memories(self, query: MemoryQuery) -> List[MemCube]:
+    """
+    Query memories based on criteria.
+
+    Supports filtering by:
+    - Project ID
+    - Tags (via JSON search)
+    - Memory type
+    - Priority
+    - Vector similarity (if embeddings available)
+    """
+    try:
+      # Compute query embedding if query text provided
+      if query.query_text and not query.embedding:
+        query.embedding = compute_embedding(query.query_text)
+
+      # Start with base query
+      q = (
+          self.client.table("memories")
+          .select("*")
+          .eq("project_id", query.project_id)
+      )
+
+      # Add type filter
+      if query.type_filter:
+        q = q.eq("type", query.type_filter.value)
+
+      # Add priority filter
+      if query.priority_filter:
+        q = q.eq("priority", query.priority_filter.value)
+
+      # Execute query
+      result = q.execute()
+
+      candidate_rows = []
+      vectors = []
+      for row in result.data:
+        if query.tags and not self._matches_tags(row, query.tags):
+          continue
+        if row.get("embedding_sig"):
+          vectors.append(np.array(row["embedding_sig"], dtype="float32"))
+          candidate_rows.append(row)
+
+      ranked_ids: List[str] = []
+      if query.embedding and vectors:
+        index = faiss.IndexFlatIP(len(query.embedding))
+        index.add(np.vstack(vectors))
+        scores, idxs = index.search(
+            np.array([query.embedding], dtype="float32"),
+            min(query.limit * 2, len(vectors)),
+        )
+        for score, idx in zip(scores[0], idxs[0]):
+          if score < query.similarity_threshold:
+            continue
+          ranked_ids.append(candidate_rows[idx]["id"])
+          if len(ranked_ids) >= query.limit:
+            break
+      else:
+        ranked_ids = [row["id"] for row in candidate_rows[: query.limit]]
+
+      memories = []
+      for mid in ranked_ids:
+        memory = await self.get_memory(mid)
+        if memory:
+          memories.append(memory)
+
+      # Include insights if requested
+      if query.include_insights and len(memories) < query.limit:
+        insights = await self._get_insight_memories(
+            query.project_id, query.limit - len(memories)
+        )
+        memories.extend(insights)
+
+      return memories
+
+    except Exception as e:
+      logger.error(f"Failed to query memories: {e}")
+      return []
+
+  async def update_memory_usage(self, memory_id: str) -> None:
+    """Update usage statistics for a memory."""
+    try:
+      # Increment usage counter and update last_used
+      now = datetime.utcnow()
+
+      result = (
+          self.client.table("memories")
+          .update({
+              "usage_hits": self.client.rpc("increment", {"value": 1}),
+              "last_used": now.isoformat(),
+          })
+          .eq("id", memory_id)
+          .execute()
+      )
+
+      # Log access event
+      await self._log_event(memory_id, "ACCESSED", "system")
+
+      # Check if should promote to HOT
+      if result.data and result.data[0]["usage_hits"] > 10:
+        await self._update_priority(memory_id, MemoryPriority.HOT)
+
+    except Exception as e:
+      logger.error(f"Failed to update usage for {memory_id}: {e}")
+
+  async def archive_memory(self, memory_id: str) -> bool:
+    """Archive a memory cube."""
+    try:
+      # Update lifecycle state
+      result = (
+          self.client.table("memories")
+          .update({
+              "lifecycle": MemoryLifecycle.ARCHIVED.value,
+              "priority": MemoryPriority.COLD.value,
+          })
+          .eq("id", memory_id)
+          .execute()
+      )
+
+      if result.data:
+        await self._log_event(memory_id, "ARCHIVED", "system")
+        return True
+
+      return False
+
+    except Exception as e:
+      logger.error(f"Failed to archive memory {memory_id}: {e}")
+      return False
+
+  async def link_memory_to_task(
+      self, memory_id: str, task_id: str, role: str = "READ"
+  ) -> bool:
+    """Create a link between memory and task."""
+    try:
+      link_data = {"memory_id": memory_id, "task_id": task_id, "role": role}
+
+      self.client.table("memory_task_links").insert(link_data).execute()
+      return True
+
+    except Exception as e:
+      logger.error(f"Failed to link memory {memory_id} to task {task_id}: {e}")
+      return False
+
+  async def get_memories_for_task(self, task_id: str) -> List[MemCube]:
+    """Get all memories linked to a task."""
+    try:
+      # Get memory IDs linked to task
+      result = (
+          self.client.table("memory_task_links")
+          .select("memory_id")
+          .eq("task_id", task_id)
+          .execute()
+      )
+
+      memories = []
+      for link in result.data:
+        memory = await self.get_memory(link["memory_id"])
+        if memory:
+          memories.append(memory)
+
+      return memories
+
+    except Exception as e:
+      logger.error(f"Failed to get memories for task {task_id}: {e}")
+      return []
+
+  # Private helper methods
+
+  def _determine_storage_mode(self, size_bytes: int) -> StorageMode:
+    """Determine storage mode based on payload size."""
+    if size_bytes < 4 * 1024:  # < 4KB
+      return StorageMode.INLINE
+    elif size_bytes < 64 * 1024:  # < 64KB
+      return StorageMode.COMPRESSED
+    else:
+      return StorageMode.COLD
+
+  async def _store_payload(
+      self, memory_id: str, payload: MemCubePayload, mode: StorageMode
+  ) -> str:
+    """Store payload based on storage mode."""
+    if mode == StorageMode.INLINE:
+      # Store directly in DB as JSON
+      if isinstance(payload.content, str):
+        return payload.content
+      elif isinstance(payload.content, bytes):
+        return base64.b64encode(payload.content).decode()
+      else:
+        return json.dumps(payload.content)
+
+    elif mode == StorageMode.COMPRESSED:
+      # Compress and store in DB
+      import gzip
+
+      content_bytes = self._serialize_payload(payload)
+      compressed = gzip.compress(content_bytes)
+      return base64.b64encode(compressed).decode()
+
+    else:  # COLD storage
+      # Store in blob storage
+      if self.blob_storage_url:
+        return await self._store_to_blob(memory_id, payload)
+      else:
+        # Fallback to compressed storage
+        return await self._store_payload(
+            memory_id, payload, StorageMode.COMPRESSED
+        )
+
+  async def _retrieve_payload(
+      self,
+      memory_id: str,
+      payload_ref: str,
+      mode: StorageMode,
+      mem_type: MemoryType,
+  ) -> Optional[MemCubePayload]:
+    """Retrieve payload based on storage mode."""
+    try:
+      if mode == StorageMode.INLINE:
+        # Direct content
+        if mem_type == MemoryType.PLAINTEXT:
+          content = payload_ref
+        elif mem_type == MemoryType.ACTIVATION:
+          content = base64.b64decode(payload_ref)
+        else:
+          content = json.loads(payload_ref)
+
+      elif mode == StorageMode.COMPRESSED:
+        # Decompress
+        import gzip
+
+        compressed = base64.b64decode(payload_ref)
+        content_bytes = gzip.decompress(compressed)
+        content = self._deserialize_payload(content_bytes, mem_type)
+
+      else:  # COLD storage
+        # Retrieve from blob
+        if self.blob_storage_url:
+          content = await self._retrieve_from_blob(memory_id)
+        else:
+          # Try as compressed
+          return await self._retrieve_payload(
+              memory_id, payload_ref, StorageMode.COMPRESSED, mem_type
+          )
+
+      return MemCubePayload(
+          type=mem_type, content=content, size_bytes=len(str(content).encode())
+      )
+
+    except Exception as e:
+      logger.error(f"Failed to retrieve payload: {e}")
+      return None
+
+  def _serialize_payload(self, payload: MemCubePayload) -> bytes:
+    """Serialize payload to bytes."""
+    if isinstance(payload.content, bytes):
+      return payload.content
+    elif isinstance(payload.content, str):
+      return payload.content.encode()
+    else:
+      return json.dumps(payload.content).encode()
+
+  def _deserialize_payload(self, data: bytes, mem_type: MemoryType) -> Any:
+    """Deserialize payload from bytes."""
+    if mem_type == MemoryType.ACTIVATION:
+      return data
+    elif mem_type == MemoryType.PLAINTEXT:
+      return data.decode()
+    else:
+      return json.loads(data.decode())
+
+  async def _store_to_blob(
+      self, memory_id: str, payload: MemCubePayload
+  ) -> str:
+    """Store payload to external blob storage."""
+    # Implementation depends on blob storage provider
+    # Return blob path/URL
+    blob_path = f"memories/{memory_id}/v{datetime.utcnow().timestamp()}"
+    # TODO: Actual blob storage implementation
+    return blob_path
+
+  async def _retrieve_from_blob(self, memory_id: str) -> Any:
+    """Retrieve payload from blob storage."""
+    # TODO: Actual blob retrieval
+    return None
+
+  def _matches_tags(self, row: Dict[str, Any], tags: List[str]) -> bool:
+    """Check if memory matches required tags."""
+    # Simple implementation - could be enhanced
+    label = row.get("label", "").lower()
+    return any(tag.lower() in label for tag in tags)
+
+  def _compute_similarity(self, vec1: List[float], vec2: List[float]) -> float:
+    """Compute cosine similarity between vectors."""
+    if len(vec1) != len(vec2):
+      return 0.0
+
+    v1 = np.array(vec1)
+    v2 = np.array(vec2)
+
+    dot_product = np.dot(v1, v2)
+    norm_product = np.linalg.norm(v1) * np.linalg.norm(v2)
+
+    if norm_product == 0:
+      return 0.0
+
+    return dot_product / norm_product
+
+  async def _update_priority(
+      self, memory_id: str, priority: MemoryPriority
+  ) -> None:
+    """Update memory priority."""
+    try:
+      self.client.table("memories").update({"priority": priority.value}).eq(
+          "id", memory_id
+      ).execute()
+
+      await self._log_event(
+          memory_id, f"PRIORITY_CHANGED_{priority.value}", "system"
+      )
+
+    except Exception as e:
+      logger.error(f"Failed to update priority: {e}")
+
+  async def _log_event(
+      self,
+      memory_id: str,
+      event: str,
+      actor: str,
+      meta: Optional[Dict[str, Any]] = None,
+  ) -> None:
+    """Log a memory event."""
+    try:
+      event_data = {
+          "memory_id": memory_id,
+          "event": event,
+          "actor": actor,
+          "ts": datetime.utcnow().isoformat(),
+          "meta": json.dumps(meta or {}),
+      }
+
+      self.client.table("memory_events").insert(event_data).execute()
+
+    except Exception as e:
+      logger.error(f"Failed to log event: {e}")
+
+  async def _get_insight_memories(
+      self, project_id: str, limit: int
+  ) -> List[MemCube]:
+    """Get insight-based memories."""
+    # TODO: Query insights table and convert to memories
+    return []
 
 
 class MemoryLifecycleManager:
-    """
-    Manages memory lifecycle transitions and cleanup.
-    
-    Handles:
-    - TTL expiration
-    - Priority decay
-    - Archive policies
-    - Cleanup tasks
-    """
-    
-    def __init__(self, storage: SupabaseMemCubeStorage):
-        self.storage = storage
-        
-    async def run_lifecycle_tasks(self) -> None:
-        """Run periodic lifecycle management tasks."""
-        await asyncio.gather(
-            self._expire_old_memories(),
-            self._decay_unused_memories(),
-            self._cleanup_orphaned_payloads()
-        )
-        
-    async def _expire_old_memories(self) -> None:
-        """Expire memories past their TTL."""
-        try:
-            # Query memories with governance data
-            result = self.storage.client.table("memories")\
-                .select("id, created_at, governance")\
-                .execute()
-                
-            now = datetime.utcnow()
-            
-            for row in result.data:
-                created_at = datetime.fromisoformat(row["created_at"])
-                governance = json.loads(row["governance"])
-                ttl_days = governance.get("ttl_days", 365)
-                
-                if now - created_at > timedelta(days=ttl_days):
-                    await self.storage.archive_memory(row["id"])
-                    logger.info(f"Expired memory {row['id']} after {ttl_days} days")
-                    
-        except Exception as e:
-            logger.error(f"Failed to expire memories: {e}")
-            
-    async def _decay_unused_memories(self) -> None:
-        """Decay priority of unused memories."""
-        try:
-            # Find memories not used in 30 days
-            cutoff = (datetime.utcnow() - timedelta(days=30)).isoformat()
-            
-            result = self.storage.client.table("memories")\
-                .select("id, priority")\
-                .lt("last_used", cutoff)\
-                .execute()
-                
-            for row in result.data:
-                current_priority = MemoryPriority(row["priority"])
-                
-                # Decay priority
-                if current_priority == MemoryPriority.HOT:
-                    new_priority = MemoryPriority.WARM
-                elif current_priority == MemoryPriority.WARM:
-                    new_priority = MemoryPriority.COLD
-                else:
-                    continue
-                    
-                await self.storage._update_priority(row["id"], new_priority)
-                
-        except Exception as e:
-            logger.error(f"Failed to decay memories: {e}")
-            
-    async def _cleanup_orphaned_payloads(self) -> None:
-        """Clean up payloads without headers."""
-        # TODO: Implement blob storage cleanup
-        pass
+  """
+  Manages memory lifecycle transitions and cleanup.
+
+  Handles:
+  - TTL expiration
+  - Priority decay
+  - Archive policies
+  - Cleanup tasks
+  """
+
+  def __init__(self, storage: SupabaseMemCubeStorage):
+    self.storage = storage
+
+  async def run_lifecycle_tasks(self) -> None:
+    """Run periodic lifecycle management tasks."""
+    await asyncio.gather(
+        self._expire_old_memories(),
+        self._decay_unused_memories(),
+        self._cleanup_orphaned_payloads(),
+    )
+
+  async def _expire_old_memories(self) -> None:
+    """Expire memories past their TTL."""
+    try:
+      # Query memories with governance data
+      result = (
+          self.storage.client.table("memories")
+          .select("id, created_at, governance")
+          .execute()
+      )
+
+      now = datetime.utcnow()
+
+      for row in result.data:
+        created_at = datetime.fromisoformat(row["created_at"])
+        governance = json.loads(row["governance"])
+        ttl_days = governance.get("ttl_days", 365)
+
+        if now - created_at > timedelta(days=ttl_days):
+          await self.storage.archive_memory(row["id"])
+          logger.info(f"Expired memory {row['id']} after {ttl_days} days")
+
+    except Exception as e:
+      logger.error(f"Failed to expire memories: {e}")
+
+  async def _decay_unused_memories(self) -> None:
+    """Decay priority of unused memories."""
+    try:
+      # Find memories not used in 30 days
+      cutoff = (datetime.utcnow() - timedelta(days=30)).isoformat()
+
+      result = (
+          self.storage.client.table("memories")
+          .select("id, priority")
+          .lt("last_used", cutoff)
+          .execute()
+      )
+
+      for row in result.data:
+        current_priority = MemoryPriority(row["priority"])
+
+        # Decay priority
+        if current_priority == MemoryPriority.HOT:
+          new_priority = MemoryPriority.WARM
+        elif current_priority == MemoryPriority.WARM:
+          new_priority = MemoryPriority.COLD
+        else:
+          continue
+
+        await self.storage._update_priority(row["id"], new_priority)
+
+    except Exception as e:
+      logger.error(f"Failed to decay memories: {e}")
+
+  async def _cleanup_orphaned_payloads(self) -> None:
+    """Clean up payloads without headers."""
+    # TODO: Implement blob storage cleanup
+    pass

--- a/tests/unittests/memcube/test_semantic_query.py
+++ b/tests/unittests/memcube/test_semantic_query.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from contributing.samples.memcube_system.in_memory_storage import InMemoryMemCubeStorage
+from contributing.samples.memcube_system.models import MemoryQuery
+from contributing.samples.memcube_system.operator import MemoryOperator
+
+
+@pytest.mark.asyncio
+async def test_query_text_returns_relevant_memory() -> None:
+  storage = InMemoryMemCubeStorage()
+  operator = MemoryOperator(storage)
+
+  m1 = await operator.create_from_text(
+      project_id="p1",
+      label="apple",
+      content="An apple a day keeps the doctor away",
+      created_by="user1",
+      tags=["fruit"],
+  )
+  m2 = await operator.create_from_text(
+      project_id="p1",
+      label="banana",
+      content="Bananas are yellow and sweet",
+      created_by="user1",
+      tags=["fruit"],
+  )
+
+  query = MemoryQuery(
+      project_id="p1", query_text="apple", limit=1, similarity_threshold=0.0
+  )
+  results = await storage.query_memories(query)
+
+  assert len(results) == 1
+  assert results[0].id == m1.id


### PR DESCRIPTION
## Summary
- implement simple character-frequency embedding backend
- generate embeddings on memory creation and update
- support vector search with FAISS in Supabase storage
- expose `query_text` and `top_k` parameters via API
- add in-memory storage for testing
- integrate semantic scoring in memory selection
- test semantic query behavior

## Testing
- `pytest tests/unittests/memcube/test_semantic_query.py -q`
- `pytest tests/unittests` *(fails: 115 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_687aca8e480c8320ad187b857ea4d449