### PR TITLE
Add usage-based memory recommendations

### DIFF
--- a/contributing/samples/memcube_system/agent_sdk.py
+++ b/contributing/samples/memcube_system/agent_sdk.py
@@ -122,6 +122,27 @@ class MemCubeClient:
       logger.error(f"Error storing memory: {e}")
       return None
 
+  async def get_recommendations(
+      self, project_id: str, limit: int = 10
+  ) -> List[Dict[str, Any]]:
+    """Fetch recommended memories for a project."""
+    if not self._session:
+      self._session = aiohttp.ClientSession()
+
+    try:
+      async with self._session.get(
+          f"{self.base_url}/memories/recommendations",
+          params={"project_id": project_id, "limit": limit},
+      ) as resp:
+        if resp.status == 200:
+          data = await resp.json()
+          return data.get("recommendations", [])
+        logger.error(f"Failed to get recommendations: {resp.status}")
+        return []
+    except Exception as e:
+      logger.error(f"Error getting recommendations: {e}")
+      return []
+
   async def submit_insight(
       self,
       agent_id: str,

--- a/contributing/samples/memcube_system/recommendation.py
+++ b/contributing/samples/memcube_system/recommendation.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
+
+from .in_memory_storage import InMemoryMemCubeStorage
+
+
+class RecommendationEngine:
+  """Compute project memory recommendations based on usage."""
+
+  def __init__(self, storage: InMemoryMemCubeStorage, interval_seconds: int = 3600):
+    self.storage = storage
+    self.interval_seconds = interval_seconds
+    self._task: Optional[asyncio.Task] = None
+
+  async def start(self) -> None:
+    if not self._task:
+      self._task = asyncio.create_task(self._run())
+
+  async def stop(self) -> None:
+    if self._task:
+      self._task.cancel()
+      try:
+        await self._task
+      except asyncio.CancelledError:
+        pass
+
+  async def _run(self) -> None:
+    while True:
+      await self.update_all_projects()
+      await asyncio.sleep(self.interval_seconds)
+
+  async def update_all_projects(self) -> None:
+    projects = {e["project_id"] for e in self.storage.events if e.get("project_id")}
+    for pid in projects:
+      self.update_project(pid)
+
+  def update_project(self, project_id: str, top_n: int = 10) -> None:
+    events = [e for e in self.storage.events if e.get("project_id")]
+    memory_projects: Dict[str, set[str]] = defaultdict(set)
+    for e in events:
+      if e["event"] == "RETRIEVED":
+        memory_projects[e["memory_id"]].add(e["project_id"])
+
+    project_memories = {
+        e["memory_id"]
+        for e in events
+        if e.get("project_id") == project_id and e["event"] == "RETRIEVED"
+    }
+
+    scores: Dict[str, float] = {}
+    for mem, projects in memory_projects.items():
+      if mem in project_memories:
+        continue
+      best = 0.0
+      for pmem in project_memories:
+        union = projects | memory_projects[pmem]
+        inter = projects & memory_projects[pmem]
+        if union:
+          sim = len(inter) / len(union)
+          if sim > best:
+            best = sim
+      if best > 0:
+        scores[mem] = best
+
+    ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)[:top_n]
+    self.storage.recommendations[project_id] = ranked
+
+  def get_recommendations(self, project_id: str, limit: int = 10) -> List[Dict[str, float]]:
+    recs = self.storage.recommendations.get(project_id, [])[:limit]
+    return [{"memory_id": mid, "score": score} for mid, score in recs]

--- a/tests/unittests/memcube/test_recommendations.py
+++ b/tests/unittests/memcube/test_recommendations.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from contributing.samples.memcube_system.in_memory_storage import InMemoryMemCubeStorage
+from contributing.samples.memcube_system.operator import MemoryOperator
+from contributing.samples.memcube_system.recommendation import RecommendationEngine
+
+
+@pytest.mark.asyncio
+async def test_project_recommendations() -> None:
+  storage = InMemoryMemCubeStorage()
+  operator = MemoryOperator(storage)
+  recommender = RecommendationEngine(storage)
+
+  m1 = await operator.create_from_text(
+      project_id="p1", label="A", content="alpha", created_by="u1", tags=[]
+  )
+  m2 = await operator.create_from_text(
+      project_id="p1", label="B", content="beta", created_by="u1", tags=[]
+  )
+  m3 = await operator.create_from_text(
+      project_id="p2", label="C", content="gamma", created_by="u2", tags=[]
+  )
+
+  # Simulate retrieval events
+  await storage._log_event(m1.id, "RETRIEVED", "u1", project_id="p1")
+  await storage._log_event(m2.id, "RETRIEVED", "u1", project_id="p1")
+  await storage._log_event(m2.id, "RETRIEVED", "u2", project_id="p2")
+  await storage._log_event(m3.id, "RETRIEVED", "u2", project_id="p2")
+
+  recommender.update_project("p2", top_n=2)
+  recs = recommender.get_recommendations("p2")
+
+  assert recs
+  assert recs[0]["memory_id"] == m1.id
+


### PR DESCRIPTION
## Summary
- log RETRIEVED events on memory lookup
- support project_id in event logging
- implement RecommendationEngine to analyze retrieval events
- expose `/memories/recommendations` endpoint
- extend MemCubeClient with recommendation API
- track events in in-memory storage
- add integration test for recommendations

## Testing
- `pytest tests/unittests/memcube/test_recommendations.py -q`
- `pytest tests/unittests` *(fails: 115 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687adde57dc483209b3a301e3701a9b0