### PR TITLE
Implement PII governance features

### DIFF
--- a/contributing/samples/memcube_system/in_memory_storage.py
+++ b/contributing/samples/memcube_system/in_memory_storage.py
@@ -129,6 +129,16 @@ class InMemoryMemCubeStorage(MemCubeStorage):
       return True
     return False
 
+  async def list_pii_memories(self, project_id: str) -> List[MemCube]:
+    return [
+        m
+        for m in self.memories.values()
+        if m.header.project_id == project_id and m.header.governance.pii_tagged
+    ]
+
+  async def get_access_logs(self, project_id: str) -> List[Dict[str, Any]]:
+    return [e for e in self.events if e.get("project_id") == project_id]
+
   async def get_chain(self, chain_id: str) -> List[MemCube]:
     ids = self.chains.get(chain_id, [])
     return [self.memories[i] for i in ids if i in self.memories]

--- a/contributing/samples/memcube_system/models.py
+++ b/contributing/samples/memcube_system/models.py
@@ -57,7 +57,7 @@ class MemoryGovernance:
   write_roles: List[str] = Field(default_factory=lambda: ["AGENT"])
   ttl_days: int = 365
   shareable: bool = True
-  license: Optional[str] = None  # SPDX identifier
+  license: List[str] = Field(default_factory=list)  # SPDX identifiers
   pii_tagged: bool = False
 
 

--- a/tests/unittests/memcube/test_pii_features.py
+++ b/tests/unittests/memcube/test_pii_features.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from contributing.samples.memcube_system import service
+from contributing.samples.memcube_system.in_memory_storage import InMemoryMemCubeStorage
+from contributing.samples.memcube_system.operator import MemoryOperator, MemorySelector, MemoryScheduler
+from contributing.samples.memcube_system.storage import SupabaseMemCubeStorage, StorageMode, MemCubePayload, MemoryType
+
+
+@pytest.fixture
+def test_app() -> TestClient:
+    storage = InMemoryMemCubeStorage()
+    service.storage = storage
+    service.operator = MemoryOperator(storage)
+    service.scheduler = MemoryScheduler(storage, MemorySelector(storage))
+    client = TestClient(service.app)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_access_returns_403(test_app: TestClient) -> None:
+    create_resp = test_app.post(
+        "/memories",
+        json={
+            "project_id": "p1",
+            "label": "pii",
+            "content": "Contact me at john@example.com",
+            "created_by": "u1",
+            "type": "PLAINTEXT",
+            "governance": {"read_roles": ["ADMIN"]},
+        },
+    )
+    mem_id = create_resp.json()["id"]
+    resp = test_app.get(f"/memories/{mem_id}?role=MEMBER")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_encrypted_payload_unreadable_without_decryption() -> None:
+    storage = SupabaseMemCubeStorage("http://x", "y")
+    payload = MemCubePayload(type=MemoryType.PLAINTEXT, content="secret")
+    ref = await storage._store_payload("m1", payload, StorageMode.INLINE, encrypt=True)
+    raw = await storage._retrieve_payload("m1", ref, StorageMode.INLINE, MemoryType.PLAINTEXT, encrypted=False)
+    assert raw.content != "secret"
+    dec = await storage._retrieve_payload("m1", ref, StorageMode.INLINE, MemoryType.PLAINTEXT, encrypted=True)
+    assert dec.content == "secret"


### PR DESCRIPTION
## Summary
- detect simple PII in `MemoryOperator` and tag memories
- encrypt payloads in storage when PII-tagged
- enforce role checks on memory retrieval and query
- store multiple SPDX licenses in `MemoryGovernance`
- add admin audit endpoint
- provide tests for PII access and encryption

## Testing
- `pytest tests/unittests/memcube/test_pii_features.py -q`
- `pytest tests/unittests -q` *(fails: 115 errors)*


------
https://chatgpt.com/codex/tasks/task_e_687bbb0cd264832093a287f2b0bbd1a6